### PR TITLE
Parallelize over forecast hours

### DIFF
--- a/adb_graphics/utils.py
+++ b/adb_graphics/utils.py
@@ -13,15 +13,15 @@ import time
 
 import numpy as np
 
-def file_exists(filename: str):
+def path_exists(path: str):
 
     ''' Checks whether a file exists, and returns the path if it does. '''
 
-    if not os.path.exists(filename):
-        msg = f'{filename} does not exist!'
+    if not os.path.exists(path):
+        msg = f'{path} does not exist!'
         raise argparse.ArgumentTypeError(msg)
 
-    return filename
+    return path
 
 def from_datetime(date):
     ''' Return a string like YYYYMMDDHH given a datetime object. '''
@@ -56,7 +56,7 @@ def get_func(val: str):
 
 
 # pylint: disable=invalid-name, too-many-locals
-def label_line(ax, label, segment, align=True, end='bottom', offset=0, **kwargs):
+def label_line(ax, label, segment, **kwargs):
 
     '''
     Label a single line with line2D label data.
@@ -68,14 +68,20 @@ def label_line(ax, label, segment, align=True, end='bottom', offset=0, **kwargs)
       ax        the SkewT object axis
       label     label to be used for the current line
       segment   a list (array) of values for the current line
+
+    Key Word Arguments
+
       align     optional bool to enable the rotation of the label to line angle
       end       the end of the line at which to put the label. 'bottom' or 'top'
       offset    index to use for the "end" of the array
 
-    Key Word Arguments
-
       Any kwargs accepted by matplotlib's text box.
     '''
+
+    # Strip non-text-box key word arguments and set default if they don't exist
+    align = kwargs.pop('align', True)
+    end = kwargs.pop('end', 'bottom')
+    offset = kwargs.pop('offset', 0)
 
     # Label location
     if end == 'bottom':
@@ -136,7 +142,7 @@ def label_lines(ax, lines, labels, offset=0, **kwargs):
 
       ax      the SkewT object axis
       lines   the SkewT object special lines
-      labels  list of labels to be used 
+      labels  list of labels to be used
       offset  index to use for the "end" of the array
 
     Key Word Arguments
@@ -151,8 +157,27 @@ def label_lines(ax, lines, labels, offset=0, **kwargs):
 
     for i, line in enumerate(lines.get_segments()):
         label = int(labels[i])
-        label = label[0] if isinstance(label, list) else label
         label_line(ax, label, line, align=True, offset=offset, **kwargs)
+
+def old_enough(age, file_path):
+
+    '''
+    Helper function to test the age of a file.
+
+    Input:
+
+      age         desired age in minutes
+      file_path   full path to file to check
+
+    Output:
+
+      bool    whether the file is at least age minutes old
+    '''
+
+    file_time = dt.datetime.fromtimestamp(os.path.getctime(file_path))
+    max_age = dt.datetime.now() - dt.timedelta(minutes=age)
+
+    return file_time < max_age
 
 def timer(func):
 

--- a/create_skewt.py
+++ b/create_skewt.py
@@ -8,15 +8,41 @@ mpl.use('Agg')
 # pylint: enable=wrong-import-position, wrong-import-order
 
 import argparse
+import copy
 import glob
 from multiprocessing import Pool
 import os
+import time
 import zipfile
 
 import matplotlib.pyplot as plt
 
 from adb_graphics.figures import skewt
 import adb_graphics.utils as utils
+
+def fhr_list(args):
+
+    '''
+    Given an arg list, return the sequence of forecast hours to process.
+
+    The length of the list will determine what forecast hours are returned:
+
+      Length = 1:   A single fhr is to be processed
+      Length = 2:   A sequence of start, stop with increment 1
+      Length = 3:   A sequence of start, stop, increment
+      Length > 3:   List as is
+
+    argparse should provide a list of at least one item (nargs='+').
+
+    Must ensure that the list contains integers.
+    '''
+
+    args = args if isinstance(args, list) else [args]
+    arg_len = len(args)
+    if arg_len in (2, 3):
+        return list(range(*args))
+
+    return args
 
 def parse_args():
 
@@ -26,23 +52,23 @@ def parse_args():
     parser = argparse.ArgumentParser(description='Script to drive the \
                                      creation of SkewT diagrams.')
 
+    # Short args
     parser.add_argument('-d',
                         dest='data_root',
                         help='Cycle-independant data directory location.',
                         required=True,
+                        type=utils.path_exists,
                         )
     parser.add_argument('-f',
                         dest='fcst_hour',
-                        help='Forecast hour',
+                        help='A list describing forecast hours.' +
+                        'If one argument, one fhr will be processed.' +
+                        'If 2 or 3 arguments, a sequence of forecast' +
+                        ' hours [start, stop, [increment]] will be ' +
+                        'processed. If more than 3 arguments, the list ' +
+                        'is processed as-is.',
+                        nargs='+',
                         required=True,
-                        type=int,
-                        )
-    parser.add_argument('--file_tmpl',
-                        default='wrfnat_hrconus_{FCST_TIME:02d}.grib2',
-                        help='File naming convention',
-                        )
-    parser.add_argument('--max_plev',
-                        help='Maximum pressure level to plot for profiles.',
                         type=int,
                         )
     parser.add_argument('-n',
@@ -62,18 +88,28 @@ def parse_args():
                         required=True,
                         type=utils.to_datetime,
                         )
-    parser.add_argument('--sites',
-                        help='Path to a sites file.',
-                        type=utils.file_exists,
-                        )
     parser.add_argument('-z',
                         dest='zip_dir',
                         help='Full path to zip directory.',
                         )
 
+    # Long args
+    parser.add_argument('--file_tmpl',
+                        default='wrfnat_hrconus_{FCST_TIME:02d}.grib2',
+                        help='File naming convention',
+                        )
+    parser.add_argument('--max_plev',
+                        help='Maximum pressure level to plot for profiles.',
+                        type=int,
+                        )
+    parser.add_argument('--sites',
+                        help='Path to a sites file.',
+                        type=utils.path_exists,
+                        )
+
     return parser.parse_args()
 
-def parallel_skewt(cla, grib_path, site, workdir):
+def parallel_skewt(cla, fhr, grib_path, site, workdir):
 
     '''
     Function that creates a single SkewT plot. Can be used in parallel.
@@ -87,7 +123,7 @@ def parallel_skewt(cla, grib_path, site, workdir):
 
     skew = skewt.SkewTDiagram(filename=grib_path, loc=site, max_plev=cla.max_plev)
     skew.create_diagram()
-    outfile = f"skewt_{skew.site_code}_{skew.site_num}_f{cla.fcst_hour:02d}.png"
+    outfile = f"skewt_{skew.site_code}_{skew.site_num}_f{fhr:02d}.png"
     png_path = os.path.join(workdir, outfile)
 
     print('*' * 80)
@@ -118,52 +154,82 @@ def prepare_skewt(cla):
 
     '''
 
-    # Locate input grib file
-    str_start_time = utils.from_datetime(cla.start_time)
-    grib_file = cla.file_tmpl.format(FCST_TIME=cla.fcst_hour)
-    grib_path = os.path.join(cla.data_root, grib_file)
-
-    if not os.path.exists(grib_path):
-        raise IOError(f"{grib_path} not found!")
-
-    # Create the working directory
-    workdir = os.path.join(cla.output_path, f"{str_start_time}{cla.fcst_hour:02d}")
-    os.makedirs(workdir, exist_ok=True)
-
     # Create an empty zip file
     zipf = None
     if cla.zip_dir:
         os.makedirs(cla.zip_dir, exist_ok=True)
-        zip_path = os.path.join(cla.zip_dir, 'files.zip')
-        zipf = zipfile.ZipFile(zip_path, 'w', zipfile.ZIP_DEFLATED)
+        zipf = os.path.join(cla.zip_dir, 'files.zip')
 
     # Load sites
     with open(cla.sites, 'r') as sites_file:
         sites = sites_file.readlines()
 
-    print((('-' * 80)+'\n') * 2)
-    print()
-    print(f'Creating graphics for input file: {grib_path}')
-    print(f'Output graphics directory: {workdir}')
-    print()
-    print((('-' * 80)+'\n') * 2)
+    fcst_hours = copy.deepcopy(cla.fcst_hour)
 
-    skewt_args = []
-    for site in sites:
-        skewt_args.append((cla, grib_path, site, workdir))
+    # Initialize a timer used for killing the program
+    timer_end = time.time()
 
-    with Pool(processes=cla.nprocs) as pool:
-        pool.starmap(parallel_skewt, skewt_args)
+    # Allow this task to run concurrently with UPP by continuing to check for
+    # new files as they become available.
+    while fcst_hours:
+        timer_sleep = time.time()
+        for fhr in fcst_hours:
+            grib_path = os.path.join(cla.data_root,
+                                     cla.file_tmpl.format(FCST_TIME=fhr))
 
-    # Zip png files and remove the original
-    if zipf:
-        png_files = glob.glob(os.path.join(workdir, '*.png'))
-        for png_file in png_files:
-            zipf.write(png_file)
-            os.remove(png_file)
+            # UPP is most likely done writing if it hasn't written in 3 mins
+            if os.path.exists(grib_path) and utils.old_enough(3, grib_path):
+                fcst_hours.remove(fhr)
+            else:
+                # Try next forecast hour
+                continue
+
+            # Create the working directory
+            workdir = os.path.join(cla.output_path,
+                                   f"{utils.from_datetime(cla.start_time)}{fhr:02d}")
+            os.makedirs(workdir, exist_ok=True)
+
+            print((('-' * 80)+'\n') * 2)
+            print()
+            print(f'Graphics will be created for input file: {grib_path}')
+            print(f'Output graphics directory: {workdir}')
+            print()
+            print((('-' * 80)+'\n') * 2)
+
+            skewt_args = [(cla, fhr, grib_path, site, workdir) for site in
+                          sites]
+
+            with Pool(processes=cla.nprocs) as pool:
+                pool.starmap(parallel_skewt, skewt_args)
+
+            # Zip png files and remove the originals
+            if zipf:
+                png_files = glob.glob(os.path.join(workdir, '*.png'))
+                with zipfile.ZipFile(zipf, 'a', zipfile.ZIP_DEFLATED) as zfile:
+                    for png_file in png_files:
+                        zfile.write(png_file)
+                        os.remove(png_file)
+
+            # Keep track of last time we did something useful
+            timer_end = time.time()
+
+        # Give up trying to process remaining forecast hours after waiting 10
+        # arbitrary mins since doing something useful.
+        if time.time() - timer_end > 600:
+            print(f"Exiting with forecast hours remaining: {fcst_hours}")
+            print((('-' * 80)+'\n') * 2)
+            break
+
+        # Wait for a bit if it's been < 2 minutes (about the length of time UPP
+        # takes) since starting last loop
+        if fcst_hours and time.time() - timer_sleep < 120:
+            print(f"Waiting for a minute before forecast hours: {fcst_hours}")
+            print((('-' * 80)+'\n') * 2)
+            time.sleep(60)
 
 
 if __name__ == '__main__':
 
     CLARGS = parse_args()
+    CLARGS.fcst_hour = fhr_list(CLARGS.fcst_hour)
     prepare_skewt(CLARGS)


### PR DESCRIPTION
Updates are mainly to the SkewT driver script. I set up the script so that it can run as a single job simultaneously with the UPP metatask. Inside the script, it does this:

- Checks to make sure that the 3D native level grib files are “old enough” (3 mins)
- If a file is ready, it creates all the SkewTs from that forecast hour in parallel using a subprocess Pool
- When the Pool is done it zips the files, so a set for a forecast hour is available for the web just a few minutes after UPP is done. (NCL waits until all are done before zipping, I think.)
- It moves on to the next forecast hour. If none are available it waits in increments of a minute until there are files that are ready.
- If nothing meaningful has happened for 10 minutes (my arbitrary choice) it releases the compute node. I chose this in case we get held up on some post jobs for a bit.

I ran a test in real-time (as me). The job ran on sjet completed the zipped files for the 18 hr forecast at 16 UTC about 8 minutes after UPP finished. The job held the single node for 72 minutes.