### PR TITLE
Modifications to make sure all our current models are working.

### DIFF
--- a/adb_graphics/datahandler/gribdata.py
+++ b/adb_graphics/datahandler/gribdata.py
@@ -11,7 +11,6 @@ from string import digits, ascii_letters
 
 from matplotlib import cm
 import numpy as np
-import xarray as xr
 
 from .. import conversions
 from .. import errors
@@ -149,7 +148,7 @@ class UPPData(specs.VarSpec):
             dim_name = [vertical_dim]
         else:
             dim_name = [var for var in self.ds.variables \
-                    if vertical_dim in var]
+                        if vertical_dim in var]
 
         # Requested level(s)
         lev_val, _ = self.numeric_level(level=level,
@@ -159,10 +158,10 @@ class UPPData(specs.VarSpec):
         levs = [self.ds[dim].values for dim in dim_name]
         if len(levs) == 2 and len(lev_val) == 2:
             levlist = [list(lev) for lev in levs]
-            for i, levset in enumerate(zip(*levlist)):
+            for index, levset in enumerate(zip(*levlist)):
                 print(f'LEVSET2: {levset, lev_val}')
                 if sorted(levset) == lev_val:
-                    return i
+                    return index
 
         if len(lev_val) == 1:
             try:
@@ -179,9 +178,11 @@ class UPPData(specs.VarSpec):
                 print(f"Could not find a level for {field.name} at {lev_val[0]} for \
                         {levarray}")
                 raise
+
             return index
 
-
+        msg = f'Length of lev_val ({len(lev_val)} or levs ({len(levs)}) bad!'
+        raise ValueError(msg)
 
         # Create a list of matching values from each requested dimension
         #idx = []
@@ -369,7 +370,8 @@ class UPPData(specs.VarSpec):
         ''' Returns the values of a given variable. '''
         ...
 
-    def vertical_dim(self, field):
+    @staticmethod
+    def vertical_dim(field):
 
         ''' Determine the vertical dimension of the variable by looking through
         the field's dimensions for one that includes "lv". Return the first

--- a/adb_graphics/datahandler/gribdata.py
+++ b/adb_graphics/datahandler/gribdata.py
@@ -303,7 +303,7 @@ class UPPData(specs.VarSpec):
                 return try_name
 
         msg = f'Could not find any of {name} in input file'
-        raise KeyError(msg)
+        raise errors.GribReadError(msg)
 
     def numeric_level(self, index_match=True, level=None, split=None):
 

--- a/adb_graphics/datahandler/gribfile.py
+++ b/adb_graphics/datahandler/gribfile.py
@@ -1,0 +1,185 @@
+# pylint: disable=invalid-name,too-few-public-methods
+
+'''
+Classes that load grib files.
+'''
+
+import abc
+import datetime
+from functools import lru_cache
+from string import digits, ascii_letters
+
+from matplotlib import cm
+import numpy as np
+import xarray as xr
+
+from .. import conversions
+from .. import errors
+from .. import specs
+from .. import utils
+
+class GribFile():
+
+    ''' Wrappers and helper functions for interfacing with pyNIO.'''
+
+    def __init__(self, filename, **kwargs):
+
+        # pylint: disable=unused-argument
+
+        self.filename = filename
+        self.contents = self._load()
+
+    def _load(self):
+
+        ''' Internal method that opens the grib file. Returns a grib message
+        iterator. '''
+
+        return xr.open_dataset(self.filename,
+                               engine='pynio',
+                               lock=False,
+                               backend_kwargs=dict(format="grib2"),
+                               )
+
+class GribFiles():
+
+    ''' Class for loading in a set of grib files and combining them over
+    forecast hours. '''
+
+    def __init__(self, coord_dims, filenames, filetype, **kwargs):
+
+        '''
+        Arguments:
+
+          coord_dims  dict containing the name of the dimension to
+                      concat (key), and a list of its values (value).
+                        Ex: {'fhr': [2, 3, 4]}
+          filenames   dict containing list of files names for the 0h and 1h
+                      forecast lead times ('01fcst'), and all the free forecast
+                      hours after that ('free_fcst').
+          filetype    key to use for dict when setting variable_names
+
+        Keyword Arguments:
+          model       string describing the model type
+        '''
+
+        self.model = kwargs.get('model', '')
+
+        self.filenames = filenames
+        self.filetype = filetype
+        self.coord_dims = coord_dims
+        self.contents = self._load()
+
+
+    def append(self, filenames):
+
+        ''' Add a single new slice to existing data set. Must match coord_dims
+        and filetype of original dataset. Updates current contents of Object'''
+
+        self.contents = self._load(filenames)
+
+    def _load(self, filenames=None):
+
+        ''' Load the set of files into a single XArray structure. '''
+
+        all_leads = [] if filenames is None else [self.contents]
+        filenames = self.filenames if filenames is None else filenames
+        var_names = self.variable_names
+
+        # 0h and 1h forecast variables are named like the keys in var_names,
+        # while the free forecast hours are named like the values in var_names.
+        # Need to do a bit of cleanup to get them into a single datastructure.
+        names = {
+            '01fcst': var_names,
+            'free_fcst': var_names.values(),
+            }
+
+        for fcst_type, vnames in names.items():
+
+            if filenames.get(fcst_type):
+                for filename in filenames.get(fcst_type):
+                    print(f'Loading grib2 file: {fcst_type}, {filename}')
+
+                if fcst_type == '01fcst':
+                    if filenames.get(fcst_type):
+                        # Rename variables to match free forecast variables
+                        all_leads.append(xr.open_mfdataset(
+                            filenames[fcst_type],
+                            **self.open_kwargs(vnames),
+                            ).rename_vars(vnames))
+                else:
+                    all_leads.append(xr.open_mfdataset(
+                        filenames[fcst_type],
+                        **self.open_kwargs(vnames),
+                        ))
+
+        ret = xr.combine_nested(all_leads,
+                                compat='override',
+                                concat_dim=list(self.coord_dims.keys())[0],
+                                coords='minimal',
+                                data_vars='minimal',
+                                )
+
+        return ret
+
+    def open_kwargs(self, vnames):
+
+        ''' Defines the key word arguments used by the various calls to XArray
+        open_mfdataset '''
+
+        return dict(
+            backend_kwargs=dict(format="grib2"),
+            combine='nested',
+            compat='override',
+            concat_dim=list(self.coord_dims.keys())[0],
+            coords='minimal',
+            data_vars=vnames,
+            engine='pynio',
+            lock=False,
+            )
+
+    @property
+    def variable_names(self):
+
+        '''
+        Defines the variable name transitions that need to happen for each
+        model to combine along forecast hours.
+
+        Keys are original variable names, values are the updated variable names.
+
+        Choosing to update the 0 and 1 hour forecast variables to the longer
+        lead times for efficiency's sake.
+        '''
+
+        names = {
+            'hrrr': {
+                'REFC_P0_L10_GLC0': 'REFC_P0_L10_GLC0',
+                'MXUPHL_P8_2L103_GLC0_max': 'MXUPHL_P8_2L103_GLC0_max1h',
+                'UGRD_P0_L103_GLC0': 'UGRD_P0_L103_GLC0',
+                'VGRD_P0_L103_GLC0': 'VGRD_P0_L103_GLC0',
+                'WEASD_P8_L1_GLC0_acc': 'WEASD_P8_L1_GLC0_acc1h',
+                'APCP_P8_L1_GLC0_acc': 'APCP_P8_L1_GLC0_acc1h',
+                'PRES_P0_L1_GLC0': 'PRES_P0_L1_GLC0',
+                'VAR_0_7_200_P8_2L103_GLC0_min': 'VAR_0_7_200_P8_2L103_GLC0_min1h',
+                },
+            'rap': {
+                'REFC_P0_L10_GLC0': 'REFC_P0_L10_GLC0',
+                'UGRD_P0_L103_GLC0': 'UGRD_P0_L103_GLC0',
+                'VGRD_P0_L103_GLC0': 'VGRD_P0_L103_GLC0',
+                'WEASD_P8_L1_GLC0_acc': 'WEASD_P8_L1_GLC0_acc1h',
+                'APCP_P8_L1_GLC0_acc': 'APCP_P8_L1_GLC0_acc1h',
+                'PRES_P0_L1_GLC0': 'PRES_P0_L1_GLC0',
+                },
+            'rrfs': {
+                'REFC_P0_L200_GLC0': 'REFC_P0_L200_GLC0',
+                'MXUPHL_P8_2L103_GLC0_max': 'MXUPHL_P8_2L103_GLC0_max1h',
+                'UGRD_P0_L103_GLC0': 'UGRD_P0_L103_GLC0',
+                'VGRD_P0_L103_GLC0': 'VGRD_P0_L103_GLC0',
+                'WEASD_P8_L1_GLC0_acc': 'WEASD_P8_L1_GLC0_acc1h',
+                'APCP_P8_L1_GLC0_acc': 'APCP_P8_L1_GLC0_acc1h',
+                'PRES_P0_L1_GLC0': 'PRES_P0_L1_GLC0',
+                'VAR_0_7_200_P8_2L103_GLC0_min': 'VAR_0_7_200_P8_2L103_GLC0_min1h',
+                },
+            }
+
+        return names[self.model]
+

--- a/adb_graphics/datahandler/gribfile.py
+++ b/adb_graphics/datahandler/gribfile.py
@@ -55,6 +55,7 @@ class GribFiles():
         self.filenames = filenames
         self.filetype = filetype
         self.coord_dims = coord_dims
+        self.grid_suffix = self._get_grid_suffix(filenames)
         self.contents = self._load()
 
 
@@ -64,6 +65,25 @@ class GribFiles():
         and filetype of original dataset. Updates current contents of Object'''
 
         self.contents = self._load(filenames)
+
+    def _get_grid_suffix(self, filenames):
+
+        ''' Return the suffix of the first variable with 4 sections (split on _)
+        in the file. This should correspond to the grid tag. '''
+
+        for files in filenames.values():
+            if files:
+                gfile = xr.open_dataset(files[0],
+                                        engine='pynio',
+                                        lock=False,
+                                        backend_kwargs=dict(format="grib2"),
+                                        )
+                for var in gfile.keys():
+                    vsplit = var.split('_')
+                    if len(vsplit) == 4:
+                        gfile.close()
+                        return vsplit[-1]
+        return 'GRID NOT FOUND'
 
     def _load(self, filenames=None):
 
@@ -138,34 +158,35 @@ class GribFiles():
         lead times for efficiency's sake.
         '''
 
+        grid = self.grid_suffix
         names = {
             'hrrr': {
-                'REFC_P0_L10_GLC0': 'REFC_P0_L10_GLC0',
-                'MXUPHL_P8_2L103_GLC0_max': 'MXUPHL_P8_2L103_GLC0_max1h',
-                'UGRD_P0_L103_GLC0': 'UGRD_P0_L103_GLC0',
-                'VGRD_P0_L103_GLC0': 'VGRD_P0_L103_GLC0',
-                'WEASD_P8_L1_GLC0_acc': 'WEASD_P8_L1_GLC0_acc1h',
-                'APCP_P8_L1_GLC0_acc': 'APCP_P8_L1_GLC0_acc1h',
-                'PRES_P0_L1_GLC0': 'PRES_P0_L1_GLC0',
-                'VAR_0_7_200_P8_2L103_GLC0_min': 'VAR_0_7_200_P8_2L103_GLC0_min1h',
+                f'REFC_P0_L10_{grid}': f'REFC_P0_L10_{grid}',
+                f'MXUPHL_P8_2L103_{grid}_max': f'MXUPHL_P8_2L103_{grid}_max1h',
+                f'UGRD_P0_L103_{grid}': f'UGRD_P0_L103_{grid}',
+                f'VGRD_P0_L103_{grid}': f'VGRD_P0_L103_{grid}',
+                f'WEASD_P8_L1_{grid}_acc': f'WEASD_P8_L1_{grid}_acc1h',
+                f'APCP_P8_L1_{grid}_acc': f'APCP_P8_L1_{grid}_acc1h',
+                f'PRES_P0_L1_{grid}': f'PRES_P0_L1_{grid}',
+                f'VAR_0_7_200_P8_2L103_{grid}_min': f'VAR_0_7_200_P8_2L103_{grid}_min1h',
                 },
             'rap': {
-                'REFC_P0_L10_GLC0': 'REFC_P0_L10_GLC0',
-                'UGRD_P0_L103_GLC0': 'UGRD_P0_L103_GLC0',
-                'VGRD_P0_L103_GLC0': 'VGRD_P0_L103_GLC0',
-                'WEASD_P8_L1_GLC0_acc': 'WEASD_P8_L1_GLC0_acc1h',
-                'APCP_P8_L1_GLC0_acc': 'APCP_P8_L1_GLC0_acc1h',
-                'PRES_P0_L1_GLC0': 'PRES_P0_L1_GLC0',
+                f'REFC_P0_L10_{grid}': f'REFC_P0_L10_{grid}',
+                f'UGRD_P0_L103_{grid}': f'UGRD_P0_L103_{grid}',
+                f'VGRD_P0_L103_{grid}': f'VGRD_P0_L103_{grid}',
+                f'WEASD_P8_L1_{grid}_acc': f'WEASD_P8_L1_{grid}_acc1h',
+                f'APCP_P8_L1_{grid}_acc': f'APCP_P8_L1_{grid}_acc1h',
+                f'PRES_P0_L1_{grid}': f'PRES_P0_L1_{grid}',
                 },
             'rrfs': {
-                'REFC_P0_L200_GLC0': 'REFC_P0_L200_GLC0',
-                'MXUPHL_P8_2L103_GLC0_max': 'MXUPHL_P8_2L103_GLC0_max1h',
-                'UGRD_P0_L103_GLC0': 'UGRD_P0_L103_GLC0',
-                'VGRD_P0_L103_GLC0': 'VGRD_P0_L103_GLC0',
-                'WEASD_P8_L1_GLC0_acc': 'WEASD_P8_L1_GLC0_acc1h',
-                'APCP_P8_L1_GLC0_acc': 'APCP_P8_L1_GLC0_acc1h',
-                'PRES_P0_L1_GLC0': 'PRES_P0_L1_GLC0',
-                'VAR_0_7_200_P8_2L103_GLC0_min': 'VAR_0_7_200_P8_2L103_GLC0_min1h',
+                f'REFC_P0_L200_{grid}': f'REFC_P0_L200_{grid}',
+                f'MXUPHL_P8_2L103_{grid}_max': f'MXUPHL_P8_2L103_{grid}_max1h',
+                f'UGRD_P0_L103_{grid}': f'UGRD_P0_L103_{grid}',
+                f'VGRD_P0_L103_{grid}': f'VGRD_P0_L103_{grid}',
+                f'WEASD_P8_L1_{grid}_acc': f'WEASD_P8_L1_{grid}_acc1h',
+                f'APCP_P8_L1_{grid}_acc': f'APCP_P8_L1_{grid}_acc1h',
+                f'PRES_P0_L1_{grid}': f'PRES_P0_L1_{grid}',
+                f'VAR_0_7_200_P8_2L103_{grid}_min': f'VAR_0_7_200_P8_2L103_{grid}_min1h',
                 },
             }
 

--- a/adb_graphics/datahandler/gribfile.py
+++ b/adb_graphics/datahandler/gribfile.py
@@ -4,19 +4,7 @@
 Classes that load grib files.
 '''
 
-import abc
-import datetime
-from functools import lru_cache
-from string import digits, ascii_letters
-
-from matplotlib import cm
-import numpy as np
 import xarray as xr
-
-from .. import conversions
-from .. import errors
-from .. import specs
-from .. import utils
 
 class GribFile():
 
@@ -182,4 +170,3 @@ class GribFiles():
             }
 
         return names[self.model]
-

--- a/adb_graphics/datahandler/gribfile.py
+++ b/adb_graphics/datahandler/gribfile.py
@@ -66,7 +66,8 @@ class GribFiles():
 
         self.contents = self._load(filenames)
 
-    def _get_grid_suffix(self, filenames):
+    @staticmethod
+    def _get_grid_suffix(filenames):
 
         ''' Return the suffix of the first variable with 4 sections (split on _)
         in the file. This should correspond to the grid tag. '''

--- a/adb_graphics/default_specs.yml
+++ b/adb_graphics/default_specs.yml
@@ -49,10 +49,6 @@
 #                        of 2D field when two or more fields are "stacked"
 #                        into a single 3D array.
 #
-#   vertical_level_name: name of variable in grib2 file that holds the level
-#                        (or bottom level of a layer) of 2D field when two or
-#                        more fields are "stacked" into a single 3D array.
-#
 #   wind: a boolean variable that switches on/off the wind barbs drawn from the
 #         wind at the same level, OR a string specifying the key for the desired
 #         wind level
@@ -357,7 +353,10 @@ echotop: # Echo Top
     clevs: !!python/object/apply:numpy.arange [4, 50, 3]
     cmap: NWSReflectivity
     colors: cref_colors
-    ncl_name: RETOP_P0_L3_{grid}
+    ncl_name: 
+      hrrr: RETOP_P0_L3_{grid}
+      rap: RETOP_P0_L3_{grid}
+      rrfs: RETOP_P0_L200_{grid}
     ticks: 0
     title: Echo Top
     transform: conversions.m_to_kft
@@ -477,84 +476,84 @@ hlcy: # Helicity
     cmap: gist_ncar
     colors: rainbow12_colors
     ncl_name: UPHL_P0_2L103_{grid}
+    split: True
     ticks: 25
     title: 1-6km Updraft Helicity
     unit: m2/s2
-    vertical_index: 1
   in25: # Hourly updraft helicity over 2-5 km layer
     <<: *hlcy
     clevs: !!python/object/apply:numpy.arange [25, 301, 25]
     ncl_name: UPHL_P0_2L103_{grid}
+    split: True
     title: 2-5km Updraft Helicity
-    vertical_index: 0
   mn02: &hlcy_mn02 # Hourly minimum of updraft helicity over 0-2 km layer
     <<: *hlcy
     clevs: !!python/object/apply:numpy.arange [12.5, 150.5, 12.5]
     ncl_name: VAR_0_7_200_P8_2L103_{grid}_min1h
+    split: True
     ticks: 12.5
     title: 0-2km Min Updraft Helicity (over prv hr)
-    vertical_index: 0
   mn03: &hlcy_mn03 # Hourly minimum of updraft helicity over 0-3 km layer
     <<: *hlcy
     clevs: !!python/object/apply:numpy.arange [12.5, 150.5, 12.5]
     ncl_name: VAR_0_7_200_P8_2L103_{grid}_min1h
+    split: True
     ticks: 12.5
     title: 0-3km Min Updraft Helicity (over prv hr)
-    vertical_index: 1
   mn16: &hlcy_mn16 # Hourly minimum of updraft helicity over 1-6 km layer
     <<: *hlcy
     clevs: !!python/object/apply:numpy.arange [25, 301, 25]
     ncl_name: VAR_0_7_200_P8_2L103_{grid}_min1h
+    split: True
     title: 1-6km Min Updraft Helicity (over prv hr)
-    vertical_index: 3
   mn25: &hlcy_mn25 # Hourly minimum of updraft helicity over 2-5 km layer
     <<: *hlcy
     clevs: !!python/object/apply:numpy.arange [25, 301, 25]
+    split: True
     ncl_name: VAR_0_7_200_P8_2L103_{grid}_min1h
     title: 2-5km Min Updraft Helicity (over prv hr)
-    vertical_index: 2
   mx02: &hlcy_mx02 # Hourly maximum of updraft helicity over 0-2 km layer
     <<: *hlcy
     clevs: !!python/object/apply:numpy.arange [12.5, 150.5, 12.5]
     ncl_name: MXUPHL_P8_2L103_{grid}_max1h
+    split: True
     ticks: 12.5
     title: 0-2km Max Updraft Helicity (over prv hr)
-    vertical_index: 0
   mx03: &hlcy_mx03 # Hourly maximum of updraft helicity over 0-3 km layer
     <<: *hlcy
     clevs: !!python/object/apply:numpy.arange [12.5, 150.5, 12.5]
     ncl_name: MXUPHL_P8_2L103_{grid}_max1h
+    split: True
     ticks: 12.5
     title: 0-3km Max Updraft Helicity (over prv hr)
-    vertical_index: 1
   mx16: &hlcy_mx16 # Hourly maximum of updraft helicity over 1-6 km layer
     <<: *hlcy
     clevs: !!python/object/apply:numpy.arange [25, 301, 25]
     ncl_name: MXUPHL_P8_2L103_{grid}_max1h
+    split: True
     title: 1-6km Max Updraft Helicity (over prv hr)
-    vertical_index: 3
   mx25: &hlcy_mx25 # Hourly maximum of updraft helicity over 2-5 km layer
     <<: *hlcy
     clevs: !!python/object/apply:numpy.arange [25, 301, 25]
     ncl_name: MXUPHL_P8_2L103_{grid}_max1h
+    split: True
     title: 2-5km Max Updraft Helicity (over prv hr)
-    vertical_index: 2
   sr01: # 0-1 km Storm Relative Helicity
     <<: *hlcy
     clevs: [25, 50, 100, 150, 200, 250, 300, 400, 500, 600, 700, 800]
     ncl_name: HLCY_P0_2L103_{grid}
     unit: $m^2 / s^2$
+    split: True
     ticks: 0
     title: 0-1 km Storm Relative Helicity
-    vertical_index: 0
   sr03: # 0-3 km Storm Relative Helicity
     <<: *hlcy
     clevs: [25, 50, 100, 150, 200, 250, 300, 400, 500, 600, 700, 800]
     ncl_name: HLCY_P0_2L103_{grid}
     unit: $m^2 / s^2$
+    split: True
     ticks: 0
     title: 0-3 km Storm Relative Helicity
-    vertical_index: 1
 hlcytot:
   mn02:
     <<: *hlcy_mn02
@@ -692,6 +691,7 @@ pres:
     colors: ps_colors
     ncl_name:
       hrrr: MSLMA_P0_L101_{grid}
+      rap: MSLMA_P0_L101_{grid}
       rrfs: PRMSL_P0_L101_{grid}
     ticks: 20
     transform: conversions.pa_to_hpa
@@ -865,7 +865,10 @@ rvil: # Radar-derived Vertically Integrated Liquid
     clevs: [0.05, 0.15, 0.76, 3.47, 6.92, 12, 31.6, 35, 40, 45, 50, 55, 60, 65, 70]
     cmap: NWSReflectivity
     colors: cref_colors
-    ncl_name: VIL_P0_L{level_type}_{grid}
+    ncl_name: 
+      hrrr: VIL_P0_L{level_type}_{grid}
+      rap: VIL_P0_L{level_type}_{grid}
+      rrfs: VIL_P0_L200_{grid}
     ticks: 0
     title: Radar-derived Vertically Integrated Liquid
     unit: kg/m^2
@@ -880,24 +883,24 @@ shear:
     cmap: jet
     colors: shear_colors
     ncl_name: VUCSH_P0_2L103_{grid}
+    split: True
     transform:
       funcs: vector_magnitude
       kwargs:
         field2: VVCSH_P0_2L103_{grid}
         one_lev: True
-        vertical_index: 0
+        split: True
     ticks: 0
     unit: $s^{-1}$
-    vertical_index: 0
   06km: # 0-6 km
     <<: *shear
+    split: True
     transform:
       funcs: vector_magnitude
       kwargs:
         field2: VVCSH_P0_2L103_{grid}
         one_lev: True
-        vertical_index: 1
-    vertical_index: 1
+        split: True
 shtfl: # Sensible Heat Net Flux
   sfc:
     <<: *heat_flux
@@ -930,7 +933,10 @@ soilm: # Soil Moisture Availability
     clevs: [0, 5, 15, 25, 35, 45, 55, 65, 75, 85, 95]
     cmap: Spectral
     colors: soilm_colors
-    ncl_name: MSTAV_P0_L106_{grid}
+    ncl_name:
+      hrrr: MSTAV_P0_L106_{grid}
+      rap: MSTAV_P0_L106_{grid}
+      rrfs: SOILM_P0_2L106_{grid}
     ticks: 0
     title: Soil Moisture Availability
     unit: "%"
@@ -943,7 +949,6 @@ soilt: # Soil Temperature
     ticks: 0
     title: Soil Temperature at Sfc
     unit: K
-    vertical_level_name: lv_DBLL10_l0
   1cm:
     <<: *soilt_levs
     title: Soil Temperature at 1cm
@@ -954,6 +959,9 @@ soilt: # Soil Temperature
     <<: *soilt_levs
     title: Soil Temperature at 10cm
   30cm:
+    <<: *soilt_levs
+    title: Soil Temperature at 30cm
+  40cm:
     <<: *soilt_levs
     title: Soil Temperature at 30cm
   60cm:
@@ -977,7 +985,6 @@ soilw: # Soil Moisture
     ticks: 0
     title: Soil Moisture at Sfc
     unit: fraction
-    vertical_level_name: lv_DBLL10_l0
   1cm:
     <<: *soilw_levs
     title: Soil Moisture at 1cm
@@ -990,6 +997,9 @@ soilw: # Soil Moisture
   30cm:
     <<: *soilw_levs
     title: Soil Moisture at 30cm
+  40cm:
+    <<: *soilw_levs
+    title: Soil Moisture at 40cm
   60cm:
     <<: *soilw_levs
     title: Soil Moisture at 60cm
@@ -1286,7 +1296,6 @@ vvort: # Vertical vorticity
     ticks: 0
     title: 0-1km Max Vertical Velocity (over prev hour)
     unit: 1/s
-    vertical_level_name: lv_HTGL11_l0
   mx02: # Hourly maximum of vertical vorticity over 0-2 km layer
     <<: *vvort 
     title: 0-2km Max Vertical Velocity (over prev hour)

--- a/adb_graphics/default_specs.yml
+++ b/adb_graphics/default_specs.yml
@@ -607,7 +607,9 @@ hpbl: # Height of Planetary Boundary Layer
 icmr: # Ice Water Mixing Ratio
   ua:
     ncl_name:
-      nat: ICMR_P0_L105_{grid}
+      nat:
+        - ICMR_P0_L105_{grid}
+        - CIMIXR_P0_L105_{grid}
       prs: ICMR_P0_L100_{grid}
 lcl: # Lifted condensation level
   sfc: &lcl
@@ -890,6 +892,7 @@ shear:
         field2: VVCSH_P0_2L103_{grid}
         one_lev: True
         split: True
+        level: 01km
     ticks: 0
     unit: $s^{-1}$
   06km: # 0-6 km
@@ -901,6 +904,7 @@ shear:
         field2: VVCSH_P0_2L103_{grid}
         one_lev: True
         split: True
+        level: 06km
 shtfl: # Sensible Heat Net Flux
   sfc:
     <<: *heat_flux

--- a/adb_graphics/figures/maps.py
+++ b/adb_graphics/figures/maps.py
@@ -178,6 +178,7 @@ class Map():
 
 
 class DataMap():
+    #pylint: disable=too-many-arguments
 
     '''
     Class that combines the input data and the chosen map to plot both together.
@@ -192,12 +193,13 @@ class DataMap():
 
     '''
 
-    def __init__(self, field, map_, contour_fields=None, hatch_fields=None):
+    def __init__(self, field, map_, contour_fields=None, hatch_fields=None, model_name=None):
 
         self.field = field
         self.contour_fields = contour_fields
         self.hatch_fields = hatch_fields
         self.map = map_
+        self.model_name = model_name
 
 
     @staticmethod
@@ -394,7 +396,7 @@ class DataMap():
         contoured = ', '.join(contoured)
 
         # Analysis time (top) and forecast hour (bottom) on the left
-        plt.title(f"Analysis: {atime}\nFcst Hr: {f.fhr}", loc='left', fontsize=16)
+        plt.title(f"{self.model_name}: {atime}\nFcst Hr: {f.fhr}", loc='left', fontsize=16)
 
         # Atmospheric level and unit in the high center
         level, lev_unit = f.numeric_level(index_match=False)

--- a/adb_graphics/figures/skewt.py
+++ b/adb_graphics/figures/skewt.py
@@ -139,17 +139,20 @@ class SkewTDiagram(gribdata.profileData):
                        f"{settings.get('units')}"
             lines.append(line)
 
+            label = f"{settings.get('label'):<7s}"
+            if scale != 1.0:
+                label = f"{settings.get('label'):<5s}(x{scale})"
             handles.append(mlines.Line2D([], [],
                                          color=settings.get('color'),
                                          fillstyle='none',
-                                         label=settings.get('label'),
+                                         label=label,
                                          linewidth=1.0,
                                          marker=settings.get('marker'),
                                          markersize=8,
                                          )
                           )
 
-        plt.legend(handles=handles, loc=[4.3, -0.8])
+        plt.legend(handles=handles, loc=[4.2, -0.8])
 
         contents = '\n'.join(lines)
         # Draw the vertically integrated amounts box

--- a/adb_graphics/figures/skewt.py
+++ b/adb_graphics/figures/skewt.py
@@ -18,11 +18,11 @@ from metpy.plots import Hodograph, SkewT
 from metpy.units import units
 from mpl_toolkits.axes_grid1.inset_locator import inset_axes
 
-import adb_graphics.datahandler.grib as grib
+import adb_graphics.datahandler.gribdata as gribdata
 import adb_graphics.errors as errors
 import adb_graphics.utils as utils
 
-class SkewTDiagram(grib.profileData):
+class SkewTDiagram(gribdata.profileData):
 
     ''' The class responsible for gathering all data needed from a grib file to
     produce a Skew-T Log-P diagram.
@@ -38,7 +38,7 @@ class SkewTDiagram(grib.profileData):
       max_plev         maximum pressure level to plot in mb
       model_name       model name to use for plotting
 
-    Additional keyword arguments for the grib.profileData base class should also
+    Additional keyword arguments for the gribdata.profileData base class should also
     be included.
     '''
 

--- a/create_graphics.py
+++ b/create_graphics.py
@@ -245,7 +245,7 @@ def parse_args():
         )
     parser.add_argument(
         '-m',
-        default='hrrr',
+        default='Unnamed Experiment',
         dest='model_name',
         help='string to use in title of graphic.',
         type=str,
@@ -426,6 +426,7 @@ def parallel_maps(cla, fhr, ds, level, model, spec, variable, workdir,
         contour_fields=contour_fields,
         hatch_fields=hatch_fields,
         map_=m,
+        model_name=cla.model_name,
         )
 
     # Draw the map

--- a/create_graphics.py
+++ b/create_graphics.py
@@ -137,6 +137,7 @@ def gather_gribfiles(cla, fhr, gribfiles):
             coord_dims={'fcst_hr': fcst_hours},
             filenames=filenames,
             filetype=cla.file_type,
+            model=cla.images[0],
             )
     else:
 
@@ -556,14 +557,15 @@ def graphics_driver(cla):
                             )
 
             # Zip png files and remove the originals in a subprocess
-            for tile, zipf in zipfiles.items():
-                png_files = glob.glob(os.path.join(workdir, f'*_{tile}_*{fhr:02d}.png'))
-                zip_proc = Process(group=None,
-                                   target=create_zip,
-                                   args=(png_files, zipf),
-                                   )
-                zip_proc.start()
-                zip_proc.join()
+            if cla.zip_dir:
+                for tile, zipf in zipfiles.items():
+                    png_files = glob.glob(os.path.join(workdir, f'*_{tile}_*{fhr:02d}.png'))
+                    zip_proc = Process(group=None,
+                                       target=create_zip,
+                                       args=(png_files, zipf),
+                                       )
+                    zip_proc.start()
+                    zip_proc.join()
 
             # Keep track of last time we did something useful
             timer_end = time.time()

--- a/create_graphics.py
+++ b/create_graphics.py
@@ -20,7 +20,8 @@ import zipfile
 import matplotlib.pyplot as plt
 import yaml
 
-from adb_graphics.datahandler import grib
+from adb_graphics.datahandler import gribfile
+from adb_graphics.datahandler import gribdata
 import adb_graphics.errors as errors
 from adb_graphics.figures import maps
 from adb_graphics.figures import skewt
@@ -35,9 +36,9 @@ def create_skewt(cla, fhr, grib_path, workdir):
     and generate a pool of workers to complete the tasks. '''
 
     # Create the file object to load the contents
-    gribfile = grib.GribFile(grib_path)
+    gfile = gribfile.GribFile(grib_path)
 
-    args = [(cla, fhr, gribfile.contents, site, workdir) for site in cla.sites]
+    args = [(cla, fhr, gfile.contents, site, workdir) for site in cla.sites]
 
     print(f'Queueing {len(args)} Skew Ts')
     with Pool(processes=cla.nprocs) as pool:
@@ -133,7 +134,7 @@ def gather_gribfiles(cla, fhr, gribfiles):
         # Create a new GribFiles object, include all hours, or just this one,
         # depending on command line argument flag
 
-        gribfiles = grib.GribFiles(
+        gribfiles = gribfile.GribFiles(
             coord_dims={'fcst_hr': fcst_hours},
             filenames=filenames,
             filetype=cla.file_type,
@@ -359,7 +360,7 @@ def parallel_maps(cla, fhr, ds, level, model, spec, variable, workdir,
     '''
 
     # Object to be plotted on the map in filled contours.
-    field = grib.fieldData(
+    field = gribdata.fieldData(
         ds=ds,
         fhr=fhr,
         filetype=cla.file_type,
@@ -385,7 +386,7 @@ def parallel_maps(cla, fhr, ds, level, model, spec, variable, workdir,
             else:
                 var, lev = contour, level
 
-            contour_fields.append(grib.fieldData(
+            contour_fields.append(gribdata.fieldData(
                 ds=ds,
                 fhr=fhr,
                 level=lev,
@@ -400,7 +401,7 @@ def parallel_maps(cla, fhr, ds, level, model, spec, variable, workdir,
     if hatches is not None:
         for hatch, hatch_kwargs in hatches.items():
             var, lev = hatch.split('_')
-            hatch_fields.append(grib.fieldData(
+            hatch_fields.append(gribdata.fieldData(
                 ds=ds,
                 fhr=fhr,
                 level=lev,

--- a/image_lists/rap.yml
+++ b/image_lists/rap.yml
@@ -3,8 +3,6 @@ hourly:
   variables:
     1hsnw:
       - sfc
-    acp:
-      - sfc
     acsnw:
       - sfc
     acfrozr:
@@ -18,11 +16,7 @@ hourly:
       - mul
       - mx90mb
       - sfc
-    cctop:
-      - ua
     ceil:
-      - ua
-    ctop:
       - ua
     cin:
       - sfc
@@ -33,9 +27,11 @@ hourly:
       - total
     cref:
       - sfc
+    ctop:
+      - ua
     dewp:
       - 2m
-    ectp:
+    echotop:
       - sfc
     flru:
       - sfc
@@ -49,7 +45,7 @@ hourly:
       - sfc
     pchg:
       - sfc
-    ptemp:
+    ptmp:
       - 2m
     ptyp:
       - sfc
@@ -67,13 +63,15 @@ hourly:
       - sfc
     snod:
       - sfc
-    soilt: &soilt_levs
+    soilt:
       - 1cm
       - 4cm
       - 10cm
     soilw:
-      <<: *soilt_levs
       - 0cm
+      - 1cm
+      - 4cm
+      - 10cm
     solar:
       - sfc
     temp:

--- a/image_lists/rap_subset.yml
+++ b/image_lists/rap_subset.yml
@@ -1,19 +1,15 @@
 hourly:
-  model: hrrr
+  model: rap
   variables:
     1hsnw:
       - sfc
-    1ref:
-      - 1000m
+    acsnw:
+      - sfc
     acfrozr:
       - sfc
     acfrzr:
       - sfc
     acpcp:
-      - sfc
-    acsnod:
-      - sfc
-    acsnw:
       - sfc
     cape:
       - mu
@@ -22,20 +18,13 @@ hourly:
       - sfc
     ceil:
       - ua
-    ceilexp:
-      - ua
-    ceilexp2:
-      - ua
     cin:
       - sfc
     cloudcover:
-      - bndylay
       - high
       - low
       - mid
       - total
-    cpofp:
-      - sfc
     cref:
       - sfc
     ctop:
@@ -46,61 +35,18 @@ hourly:
       - sfc
     flru:
       - sfc
-    G113bt:
-      - sat
-    G114bt:
-      - sat
-    G123bt:
-      - sat
-    G124bt:
-      - sat
     gust:
       - 10m
-    hail:
-      - max
-      - maxsfc
-    hailcast:
-      - maxsfc
-    hlcy:
-      - in25
-      - mn02
-      - mn03
-      - mn25
-      - mx02
-      - mx03
-      - mx25
-      - sr01
-      - sr03
-    hlcytot:
-      - mn02
-      - mn03
-      - mn25
-      - mx02
-      - mx03
-      - mx25
     hpbl:
-      - sfc
-    lcl:
       - sfc
     lhtfl:
       - sfc
-    li:
-      - best
-      - sfc
-    ltg3:
-      - sfc
-    mref:
-      - sfc
-    pres:
-      - msl
-      - sfc
     ptmp:
       - 2m
+    ptyp:
+      - sfc
     pwtr:
       - sfc
-    ref:
-      - m10
-      - maxm10
     rh:
       - 2m
       - 850mb
@@ -108,29 +54,20 @@ hourly:
       - pw
     rvil:
       - sfc
-    shear:
-      - 01km
-      - 06km
     shtfl:
       - sfc
     snod:
       - sfc
-    soilm:
-      - sfc
-    soilt: &soilt_levs
+    soilt:
+      - 1cm
+      - 4cm
+      - 10cm
+    soilw:
       - 0cm
       - 1cm
       - 4cm
       - 10cm
-      - 30cm
-      - 60cm
-      - 1m
-      - 1.6m
-      - 3m
-    soilw: *soilt_levs
     solar:
-      - sfc
-    ssrun:
       - sfc
     temp:
       - 2ds
@@ -148,12 +85,6 @@ hourly:
     uswrf:
       - sfc
       - top
-    vbdsf:
-      - sfc
-    vddsf:
-      - sfc
-    vig:
-      - sfc
     vil:
       - sfc
     vis:
@@ -162,10 +93,6 @@ hourly:
       - 500mb
     vvel:
       - 700mb
-      - mean
-    vvort:
-      - mx01
-      - mx02
     weasd:
       - sfc
     wspeed:
@@ -173,6 +100,3 @@ hourly:
       - 80m
       - 250mb
       - 850mb
-      - max
-      - mdn
-      - mup

--- a/image_lists/rrfs_subset.yml
+++ b/image_lists/rrfs_subset.yml
@@ -5,7 +5,15 @@ hourly:
       - sfc
     1ref:
       - 1000m
+    acfrozr:
+      - sfc
+    acfrzr:
+      - sfc
     acpcp:
+      - sfc
+    acsnod:
+      - sfc
+    acsnw:
       - sfc
     cape:
       - mu
@@ -14,46 +22,109 @@ hourly:
       - sfc
     ceil:
       - ua
+    ceilexp:
+      - ua
+    ceilexp2:
+      - ua
     cin:
       - sfc
     cloudcover:
+      - bndylay
       - high
       - low
       - mid
       - total
+    cpofp:
+      - sfc
     cref:
       - sfc
     ctop:
       - ua
     dewp:
       - 2m
+    echotop:
+      - sfc
     flru:
       - sfc
+    G113bt:
+      - sat
+    G114bt:
+      - sat
+    G123bt:
+      - sat
+    G124bt:
+      - sat
     gust:
       - 10m
+    hail:
+      - max
+      - maxsfc
+    hailcast:
+      - maxsfc
     hlcy:
+      - in25
+      - mn03
+      - mn25
+      - mx03
+      - mx25
       - sr01
       - sr03
+    hlcytot:
+      - mn03
+      - mn25
+      - mx03
+      - mx25
+    hpbl:
+      - sfc
     lcl:
       - sfc
     lhtfl:
       - sfc
     li:
       - best
-    pres:
       - sfc
+    ltg3:
+      - sfc
+    mref:
+      - sfc
+    pres:
+      - msl
+      - sfc
+    ptmp:
+      - 2m
     pwtr:
       - sfc
+    ref:
+      - m10
+      - maxm10
     rh:
       - 2m
       - 850mb
+      - mean
+      - pw
     rvil:
       - sfc
+    shear:
+      - 01km
+      - 06km
     shtfl:
       - sfc
+    snod:
+      - sfc
+    soilm:
+      - sfc
+    soilt: &soilt_levs
+      - 0cm
+      - 10cm
+      - 40cm
+      - 1m
+    soilw: *soilt_levs
     solar:
       - sfc
+    ssrun:
+      - sfc
     temp:
+      - 2ds
       - 2m
       - 500mb
       - 700mb
@@ -64,12 +135,28 @@ hourly:
       - sfc
     ulwrf:
       - sfc
+      - top
     uswrf:
+      - sfc
+      - top
+    vbdsf:
+      - sfc
+    vddsf:
+      - sfc
+    vig:
+      - sfc
+    vil:
       - sfc
     vis:
       - sfc
+    vort:
+      - 500mb
     vvel:
       - 700mb
+      - mean
+    vvort:
+      - mx01
+      - mx02
     weasd:
       - sfc
     wspeed:
@@ -77,3 +164,6 @@ hourly:
       - 80m
       - 250mb
       - 850mb
+      - max
+      - mdn
+      - mup

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -25,7 +25,7 @@ import numpy as np
 import adb_graphics.conversions as conversions
 import adb_graphics.specs as specs
 import adb_graphics.utils as utils
-import adb_graphics.datahandler.grib as grib
+import adb_graphics.datahandler.gribdata as gribdata
 
 def test_conversion():
 
@@ -135,6 +135,7 @@ class TestDefaultSpecs():
             'labels': self.is_a_contourf_dict,
             'ncl_name': True,
             'print_units': True,
+            'split': self.is_bool,
             'ticks': self.is_number,
             'title': self.is_string,
             'transform': self.check_transform,
@@ -251,14 +252,14 @@ class TestDefaultSpecs():
         if func in dir(self.varspec):
             return self.varspec.__getattribute__(func)
 
-        # Check datahandler.grib objects if a single word is provided
+        # Check datahandler.gribdata objects if a single word is provided
         if len(func.split('.')) == 1:
 
             funcs = []
-            for attr in dir(grib):
+            for attr in dir(gribdata):
                 # pylint: disable=no-member
-                if func in dir(grib.__getattribute__(attr)):
-                    funcs.append(grib.__getattribute__(attr).__dict__.get(func))
+                if func in dir(gribdata.__getattribute__(attr)):
+                    funcs.append(gribdata.__getattribute__(attr).__dict__.get(func))
             return funcs
 
         if callable(utils.get_func(func)):

--- a/tests/test_grib.py
+++ b/tests/test_grib.py
@@ -7,16 +7,17 @@ import numpy as np
 from matplotlib import colors as mcolors
 import xarray
 
-import adb_graphics.datahandler.grib as grib
+import adb_graphics.datahandler.gribdata as gribdata
+import adb_graphics.datahandler.gribfile as gribfile
 
 def test_UPPData(natfile, prsfile):
 
     ''' Test the UPPData class methods on both types of input files. '''
 
-    nat_ds = grib.GribFile(natfile)
-    prs_ds = grib.GribFile(prsfile)
+    nat_ds = gribfile.GribFile(natfile)
+    prs_ds = gribfile.GribFile(prsfile)
 
-    class UPP(grib.UPPData):
+    class UPP(gribdata.UPPData):
 
         ''' Test class needed to define the values as an abstract class '''
 
@@ -48,8 +49,8 @@ def test_fieldData(prsfile):
 
     ''' Test the fieldData class methods on a prs file'''
 
-    prs_ds = grib.GribFile(prsfile)
-    field = grib.fieldData(prs_ds.contents, fhr=2, level='500mb', short_name='temp')
+    prs_ds = gribfile.GribFile(prsfile)
+    field = gribdata.fieldData(prs_ds.contents, fhr=2, level='500mb', short_name='temp')
 
     assert isinstance(field.cmap, mcolors.Colormap)
     assert isinstance(field.colors, np.ndarray)
@@ -77,7 +78,7 @@ def test_fieldData(prsfile):
     assert np.array_equal(field.get_transform('conversions.k_to_f', field.values()), \
                           (field.values() - 273.15) * 9/5 +32)
 
-    field2 = grib.fieldData(prs_ds.contents, fhr=2, level='ua', short_name='ceil')
+    field2 = gribdata.fieldData(prs_ds.contents, fhr=2, level='ua', short_name='ceil')
     transforms = field2.vspec.get('transform')
     assert np.array_equal(field2.get_transform(transforms, field2.values()), \
                           field2.field_diff(field2.values(), variable2='gh', level2='sfc') / 304.8)
@@ -91,9 +92,9 @@ def test_profileData(natfile):
 
     ''' Test the profileData class methods on a nat file'''
 
-    nat_ds = grib.GribFile(natfile)
+    nat_ds = gribfile.GribFile(natfile)
     loc = ' BNA   9999 99999  36.12  86.69  597 Nashville, TN\n'
-    profile = grib.profileData(nat_ds.contents, fhr=2, filetype='nat', loc=loc, short_name='temp')
+    profile = gribdata.profileData(nat_ds.contents, fhr=2, filetype='nat', loc=loc, short_name='temp')
 
     assert isinstance(profile.get_xypoint(), tuple)
     assert isinstance(profile.values(), xarray.DataArray)

--- a/tests/test_grib.py
+++ b/tests/test_grib.py
@@ -94,7 +94,12 @@ def test_profileData(natfile):
 
     nat_ds = gribfile.GribFile(natfile)
     loc = ' BNA   9999 99999  36.12  86.69  597 Nashville, TN\n'
-    profile = gribdata.profileData(nat_ds.contents, fhr=2, filetype='nat', loc=loc, short_name='temp')
+    profile = gribdata.profileData(nat_ds.contents,
+                                   fhr=2,
+                                   filetype='nat',
+                                   loc=loc,
+                                   short_name='temp',
+                                   )
 
     assert isinstance(profile.get_xypoint(), tuple)
     assert isinstance(profile.values(), xarray.DataArray)


### PR DESCRIPTION
PEP8 standards required splitting the adb_graphics/datahanlder/grib.py module into two as it had gotten too long.

The vertical_index flag is used in far fewer variables now, since we can't expect levels to be consistent across model output files. For example, 06km level now splits the level label into a list and looks for the vertical levels defined in the file that correspond to [0, 6000]

Added functionality to define a list of potential NCL names since hrrr and hrrrx define a few differently. 

Removed a couple of variables from image lists to match what is available in real-time with operational rap/hrrr files.