### PR TITLE
Change output filenames for Skew-T to use 3 digit forecasts

### DIFF
--- a/create_graphics.py
+++ b/create_graphics.py
@@ -475,7 +475,7 @@ def parallel_skewt(cla, fhr, ds, site, workdir):
         model_name=cla.model_name,
         )
     skew.create_diagram()
-    outfile = f"{skew.site_code}_{skew.site_num}_skewt_f{fhr:02d}.png"
+    outfile = f"{skew.site_code}_{skew.site_num}_skewt_f{fhr:03d}.png"
     png_path = os.path.join(workdir, outfile)
 
     print('*' * 80)


### PR DESCRIPTION
This is literally a one-character change in the code.  It makes the skew-t output file names end in "fNNN.png" rather than "fNN.png".