### PR TITLE
small changes to resize the maps and NOAA logo

### DIFF
--- a/adb_graphics/figures/maps.py
+++ b/adb_graphics/figures/maps.py
@@ -207,7 +207,7 @@ class DataMap():
 
         ''' Puts the NOAA logo at the bottom left of the matplotlib axes. '''
 
-        logo = mpimg.imread('static/noaa-logo-100x100.png')
+        logo = mpimg.imread('static/noaa-logo-50x50.png')
 
         imagebox = mpob.OffsetImage(logo)
         ab = mpob.AnnotationBbox(

--- a/create_graphics.py
+++ b/create_graphics.py
@@ -410,7 +410,7 @@ def parallel_maps(cla, fhr, ds, level, model, spec, variable, workdir,
                 short_name=var,
                 ))
 
-    _, ax = plt.subplots(1, 1, figsize=(12, 12))
+    _, ax = plt.subplots(1, 1, figsize=(10, 10))
 
     # Generate a map object
     m = maps.Map(


### PR DESCRIPTION
Resets the map size from 12x12 to 10x10, to reduce the size of zip files.

Also use the smaller NOAA logo to better fit the new plot size.

Passed pylint but not pytest, will look into that if it fails on GitHub tests.

Example plots, screenshots so not sure if the resizing will be apparent.  Reduced sizes from roughly 450 kb to 350 kb (80% of original)

Old:
<img width="1042" alt="Screen Shot 2021-05-04 at 2 47 06 PM" src="https://user-images.githubusercontent.com/56739562/117073712-8563bf00-acef-11eb-8a59-67ffd484885c.png">

New:
<img width="856" alt="Screen Shot 2021-05-04 at 2 47 43 PM" src="https://user-images.githubusercontent.com/56739562/117073721-87c61900-acef-11eb-82de-ef65d8ff2298.png">
