### PR TITLE
Fixes for RRFS, HLCY Titles, and Title font size

### DIFF
--- a/adb_graphics/datahandler/gribfile.py
+++ b/adb_graphics/datahandler/gribfile.py
@@ -80,12 +80,12 @@ class GribFiles():
 
             # Because there doesn't seem to be another way to know....
             odd_variables = [
-               'ASNOW',
-               'FRZR',
-               'LRGHR',
-               'TCDC',
-               'CDLYR',
-               ]
+                'ASNOW',
+                'CDLYR',
+                'FRZR',
+                'LRGHR',
+                'TCDC',
+                ]
             needs_renaming = var.split('_')[0] not in odd_variables
 
             if suffix in ['max', 'min', 'acc', 'avg'] and needs_renaming:

--- a/adb_graphics/figures/maps.py
+++ b/adb_graphics/figures/maps.py
@@ -469,4 +469,5 @@ class DataMap():
         ''' Helper function to create mesh for various plot. '''
 
         lat, lon = field.latlons()
-        return self.map.m(360+lon, lat)
+        adjust = 360 if np.any(lon < 0) else 0
+        return self.map.m(adjust + lon, lat)

--- a/adb_graphics/figures/maps.py
+++ b/adb_graphics/figures/maps.py
@@ -395,8 +395,11 @@ class DataMap():
         contoured = ', '.join(contoured)
 
         # Analysis time (top) and forecast hour (bottom) on the left
-        plt.title(f"{self.model_name}: {atime}\nFcst Hr: {f.fhr}", loc='left',
-                fontsize=14, alpha=None)
+        plt.title(f"{self.model_name}: {atime}\nFcst Hr: {f.fhr}",
+                  alpha=None,
+                  fontsize=14,
+                  loc='left',
+                  )
 
         # Add "experimental" label
         if self.model_name not in ['RAP-NCEP', 'HRRR-NCEP']:

--- a/environment.yml
+++ b/environment.yml
@@ -12,3 +12,4 @@ dependencies:
   - pylint=2.4*
   - pytest=6.1*
   - pyyaml=5.3.1
+  - xarray=0.15.1


### PR DESCRIPTION
This PR changes the following:

 - Titles for hlcy plots that showed the incorrect levels (0-6 km -> 0-3km)
 - RRFS variables that shouldn't be renamed for accumulating variables
 - Title font size adjustment for the smaller maps

