### PR TITLE
add rtma_ncep.yml to image_lists

### DIFF
--- a/image_lists/rtma_ncep.yml
+++ b/image_lists/rtma_ncep.yml
@@ -1,0 +1,14 @@
+hourly:
+  model: hrrr
+  variables:
+    dewp:
+      - 2m
+    pres:
+      - sfc
+    temp:
+      - 2m
+    vis:
+      - sfc
+    wspeed:
+      - 10m
+      - 80m


### PR DESCRIPTION
Added a new file to image_lists, rtma_ncep.yml, since products are limited from those files.  Also avoids an error resulting from the 2m - skin temperature plot, since only 2m temperature is available.