### PR TITLE
Temp colors quickfix

### DIFF
--- a/adb_graphics/datahandler/gribdata.py
+++ b/adb_graphics/datahandler/gribdata.py
@@ -251,6 +251,29 @@ class UPPData(specs.VarSpec):
                 val = utils.get_func(transform)(val, **transform_kwargs)
         return val
 
+    @lru_cache()
+    def get_xypoint(self, site_lat, site_lon) -> tuple:
+
+        '''
+        Return the X, Y grid point corresponding to the site location. No
+        interpolation is used.
+        '''
+
+        lats, lons = self.latlons()
+        max_x, max_y = np.shape(lats)
+
+        # Numpy magic to grab the X, Y grid point nearest the profile site
+        # pylint: disable=unbalanced-tuple-unpacking
+        x, y = np.unravel_index((np.abs(lats - site_lat) \
+               + np.abs(lons - site_lon)).argmin(), lats.shape)
+        # pylint: enable=unbalanced-tuple-unpacking
+
+        if x == 0 or y == 0 or x == max_x or y == max_y:
+            msg = f"site location is outside your domain!"
+#            raise errors.OutsideDomain(msg)
+
+        return (x, y)
+
     @property
     def grid_suffix(self):
 
@@ -786,28 +809,28 @@ class profileData(UPPData):
         self.site_lat = float(lat)
         self.site_lon = -float(lon)
 
-    @lru_cache()
-    def get_xypoint(self) -> tuple:
-
-        '''
-        Return the X, Y grid point corresponding to the site location. No
-        interpolation is used.
-        '''
-
-        lats, lons = self.latlons()
-        max_x, max_y = np.shape(lats)
-
-        # Numpy magic to grab the X, Y grid point nearest the profile site
-        # pylint: disable=unbalanced-tuple-unpacking
-        x, y = np.unravel_index((np.abs(lats - self.site_lat) \
-               + np.abs(lons - self.site_lon)).argmin(), lats.shape)
-        # pylint: enable=unbalanced-tuple-unpacking
-
-        if x == 0 or y == 0 or x == max_x or y == max_y:
-            msg = f"{self.site_name} is outside your domain!"
-            raise errors.OutsideDomain(msg)
-
-        return (x, y)
+#    @lru_cache()
+#    def get_xypoint(self) -> tuple:
+#
+#        '''
+#        Return the X, Y grid point corresponding to the site location. No
+#        interpolation is used.
+#        '''
+#
+#        lats, lons = self.latlons()
+#        max_x, max_y = np.shape(lats)
+#
+#        # Numpy magic to grab the X, Y grid point nearest the profile site
+#        # pylint: disable=unbalanced-tuple-unpacking
+#        x, y = np.unravel_index((np.abs(lats - self.site_lat) \
+#               + np.abs(lons - self.site_lon)).argmin(), lats.shape)
+#        # pylint: enable=unbalanced-tuple-unpacking
+#
+#        if x == 0 or y == 0 or x == max_x or y == max_y:
+#            msg = f"{self.site_name} is outside your domain!"
+#            raise errors.OutsideDomain(msg)
+#
+#        return (x, y)
 
     def values(self, level=None, name=None, **kwargs):
 
@@ -840,7 +863,7 @@ class profileData(UPPData):
         split = kwargs.get('split')
 
         # Retrive the location for the profile
-        x, y = self.get_xypoint()
+        x, y = self.get_xypoint(self.site_lat, self.site_lon)
 
         # Retrieve the default_specs section for the specified level
         var_spec = self.spec.get(name, {}).get(level, {})

--- a/adb_graphics/datahandler/gribdata.py
+++ b/adb_graphics/datahandler/gribdata.py
@@ -268,9 +268,9 @@ class UPPData(specs.VarSpec):
                + np.abs(lons - site_lon)).argmin(), lats.shape)
         # pylint: enable=unbalanced-tuple-unpacking
 
-        if x == 0 or y == 0 or x == max_x or y == max_y:
-            msg = f"site location is outside your domain!"
-#            raise errors.OutsideDomain(msg)
+        if x <= 0 or y <= 0 or x >= max_x or y >= max_y:
+            print(f'site location is outside your domain! {site_lat} {site_lon}')
+            return(-1.E10, -1.E10)
 
         return (x, y)
 

--- a/adb_graphics/datahandler/gribdata.py
+++ b/adb_graphics/datahandler/gribdata.py
@@ -809,29 +809,6 @@ class profileData(UPPData):
         self.site_lat = float(lat)
         self.site_lon = -float(lon)
 
-#    @lru_cache()
-#    def get_xypoint(self) -> tuple:
-#
-#        '''
-#        Return the X, Y grid point corresponding to the site location. No
-#        interpolation is used.
-#        '''
-#
-#        lats, lons = self.latlons()
-#        max_x, max_y = np.shape(lats)
-#
-#        # Numpy magic to grab the X, Y grid point nearest the profile site
-#        # pylint: disable=unbalanced-tuple-unpacking
-#        x, y = np.unravel_index((np.abs(lats - self.site_lat) \
-#               + np.abs(lons - self.site_lon)).argmin(), lats.shape)
-#        # pylint: enable=unbalanced-tuple-unpacking
-#
-#        if x == 0 or y == 0 or x == max_x or y == max_y:
-#            msg = f"{self.site_name} is outside your domain!"
-#            raise errors.OutsideDomain(msg)
-#
-#        return (x, y)
-
     def values(self, level=None, name=None, **kwargs):
 
         '''

--- a/adb_graphics/default_specs.yml
+++ b/adb_graphics/default_specs.yml
@@ -1054,9 +1054,9 @@ temp: # Temperature
     unit: F
     wind: False
   2m:
-    clevs: !!python/object/apply:numpy.arange [-60, 120, 2]
+    clevs: !!python/object/apply:numpy.arange [-60, 121, 2]
     cmap: jet
-    colors: t_colors
+    colors: tsfc_colors
     ncl_name: TMP_P0_L103_{grid}
     ticks: 10
     transform: conversions.k_to_f

--- a/adb_graphics/default_specs.yml
+++ b/adb_graphics/default_specs.yml
@@ -5,6 +5,10 @@
 #   accumulate: bool to specify whether there should be multiple forecast hours
 #               present in the FieldData object
 #
+#   annotate: bool to add data values at airport locations (default: True)
+#
+#   annotate_decimal: sets the decimal place for plotting values (default: 0)
+#
 #   clevs: specifies the contour levels by one of the following methods
 #      - a list with no quotes
 #      - a numpy.arange specified as "!!python/object/apply:numpy.arange [list]"
@@ -1145,6 +1149,7 @@ thick:
 totp: # Hourly total precipitation
   sfc:
     <<: *precip
+    annotate_decimal: 2
     contours:
       pres_msl:
         colors: red

--- a/adb_graphics/default_specs.yml
+++ b/adb_graphics/default_specs.yml
@@ -1058,7 +1058,8 @@ temp: # Temperature
     unit: F
     wind: False
   2m:
-    clevs: !!python/object/apply:numpy.arange [-60, 121, 2]
+#    clevs: !!python/object/apply:numpy.arange [-60, 121, 2]
+    clevs: !!python/object/apply:numpy.arange [-60, 121, 4]
     cmap: jet
     colors: tsfc_colors
     ncl_name: TMP_P0_L103_{grid}

--- a/adb_graphics/default_specs.yml
+++ b/adb_graphics/default_specs.yml
@@ -5,7 +5,7 @@
 #   accumulate: bool to specify whether there should be multiple forecast hours
 #               present in the FieldData object
 #
-#   annotate: bool to add data values at airport locations (default: True)
+#   annotate: bool to add data values at airport locations (default: False)
 #
 #   annotate_decimal: sets the decimal place for plotting values (default: 0)
 #
@@ -1058,7 +1058,7 @@ temp: # Temperature
     unit: F
     wind: False
   2m:
-#    clevs: !!python/object/apply:numpy.arange [-60, 121, 2]
+    annotate: True
     clevs: !!python/object/apply:numpy.arange [-60, 121, 4]
     cmap: jet
     colors: tsfc_colors
@@ -1128,9 +1128,9 @@ temp: # Temperature
         hatches: ['', '...']
         levels: [0, 925]
   sfc:
-    clevs: !!python/object/apply:numpy.arange [-60, 120, 10]
+    clevs: !!python/object/apply:numpy.arange [-60, 120, 4]
     cmap: jet
-    colors: t_colors
+    colors: tsfc_colors
     ncl_name: TMP_P0_L1_{grid}
     ticks: 20
     transform: conversions.k_to_f
@@ -1150,7 +1150,6 @@ thick:
 totp: # Hourly total precipitation
   sfc:
     <<: *precip
-    annotate_decimal: 2
     contours:
       pres_msl:
         colors: red

--- a/adb_graphics/default_specs.yml
+++ b/adb_graphics/default_specs.yml
@@ -1054,7 +1054,7 @@ temp: # Temperature
     unit: F
     wind: False
   2m:
-    clevs: !!python/object/apply:numpy.arange [-60, 120, 10]
+    clevs: !!python/object/apply:numpy.arange [-60, 120, 2]
     cmap: jet
     colors: t_colors
     ncl_name: TMP_P0_L103_{grid}

--- a/adb_graphics/figures/maps.py
+++ b/adb_graphics/figures/maps.py
@@ -339,10 +339,13 @@ class DataMap():
         lons = self.map.airports[:, 1]
         x, y = self.map.m(lons, lats)
         for i, lat in enumerate(lats):
-            xgrid, ygrid = self.field.get_xypoint(lats[i], lons[i])
-            data_value = self.field.values()[xgrid,ygrid]
-            if not isnan(data_value):
-                ax.annotate(f"{data_value:.0f}", xy=(x[i], y[i]), fontsize=10)
+            if lats[i] > self.map.corners[0] and lats[i] < self.map.corners[1] and \
+                lons[i] > self.map.corners[2] and lons[i] < self.map.corners[3]:
+                xgrid, ygrid = self.field.get_xypoint(lats[i], lons[i])
+                if xgrid > 0 and ygrid > 0:
+                    data_value = self.field.values()[xgrid,ygrid]
+                    if not isnan(data_value):
+                        ax.annotate(f"{data_value:.0f}", xy=(x[i], y[i]), fontsize=10)
 
         # Finish with the title
         self._title()

--- a/adb_graphics/figures/maps.py
+++ b/adb_graphics/figures/maps.py
@@ -250,7 +250,7 @@ class DataMap():
         cbar.ax.set_xticklabels(ticks, fontsize=18)
 
     @utils.timer
-    def draw(self, show=False): # pylint: disable=too-many-locals
+    def draw(self, show=False): # pylint: disable=too-many-locals, too-many-branches
 
         ''' Main method for creating the plot. Set show=True to display the
         figure from the command line. '''
@@ -335,7 +335,7 @@ class DataMap():
             self._wind_barbs(add_wind)
 
         # Add field values at airports
-        annotate = self.field.vspec.get('annotate', True)
+        annotate = self.field.vspec.get('annotate', False)
         if annotate:
             annotate_decimal = self.field.vspec.get('annotate_decimal', 0)
             lats = self.map.airports[:, 0]
@@ -343,12 +343,13 @@ class DataMap():
             x, y = self.map.m(lons, lats)
             for i, lat in enumerate(lats):
                 if lats[i] > self.map.corners[0] and lats[i] < self.map.corners[1] and \
-                    lons[i] > self.map.corners[2] and lons[i] < self.map.corners[3]:
+                   lons[i] > self.map.corners[2] and lons[i] < self.map.corners[3]:
                     xgrid, ygrid = self.field.get_xypoint(lats[i], lons[i])
                     if xgrid > 0 and ygrid > 0:
-                        data_value = self.field.values()[xgrid,ygrid]
-                        if (not isnan(data_value)) and (data_value != 0.0):
-                            ax.annotate(f"{data_value:.{annotate_decimal}f}", xy=(x[i], y[i]), fontsize=10)
+                        data_value = self.field.values()[xgrid, ygrid]
+                        if (not isnan(data_value)) and (data_value != 0.):
+                            ax.annotate(f"{data_value:.{annotate_decimal}f}", \
+                                        xy=(x[i], y[i]), fontsize=10)
 
         # Finish with the title
         self._title()

--- a/adb_graphics/figures/maps.py
+++ b/adb_graphics/figures/maps.py
@@ -335,17 +335,20 @@ class DataMap():
             self._wind_barbs(add_wind)
 
         # Add field values at airports
-        lats = self.map.airports[:, 0]
-        lons = self.map.airports[:, 1]
-        x, y = self.map.m(lons, lats)
-        for i, lat in enumerate(lats):
-            if lats[i] > self.map.corners[0] and lats[i] < self.map.corners[1] and \
-                lons[i] > self.map.corners[2] and lons[i] < self.map.corners[3]:
-                xgrid, ygrid = self.field.get_xypoint(lats[i], lons[i])
-                if xgrid > 0 and ygrid > 0:
-                    data_value = self.field.values()[xgrid,ygrid]
-                    if not isnan(data_value):
-                        ax.annotate(f"{data_value:.0f}", xy=(x[i], y[i]), fontsize=10)
+        annotate = self.field.vspec.get('annotate', True)
+        if annotate:
+            annotate_decimal = self.field.vspec.get('annotate_decimal', 0)
+            lats = self.map.airports[:, 0]
+            lons = self.map.airports[:, 1]
+            x, y = self.map.m(lons, lats)
+            for i, lat in enumerate(lats):
+                if lats[i] > self.map.corners[0] and lats[i] < self.map.corners[1] and \
+                    lons[i] > self.map.corners[2] and lons[i] < self.map.corners[3]:
+                    xgrid, ygrid = self.field.get_xypoint(lats[i], lons[i])
+                    if xgrid > 0 and ygrid > 0:
+                        data_value = self.field.values()[xgrid,ygrid]
+                        if (not isnan(data_value)) and (data_value != 0.0):
+                            ax.annotate(f"{data_value:.{annotate_decimal}f}", xy=(x[i], y[i]), fontsize=10)
 
         # Finish with the title
         self._title()

--- a/adb_graphics/figures/maps.py
+++ b/adb_graphics/figures/maps.py
@@ -342,9 +342,9 @@ class DataMap():
             lons = self.map.airports[:, 1]
             x, y = self.map.m(lons, lats)
             for i, lat in enumerate(lats):
-                if lats[i] > self.map.corners[0] and lats[i] < self.map.corners[1] and \
-                   lons[i] > self.map.corners[2] and lons[i] < self.map.corners[3]:
-                    xgrid, ygrid = self.field.get_xypoint(lats[i], lons[i])
+                if self.map.corners[1] > lat > self.map.corners[0] and \
+                   self.map.corners[3] > lons[i] > self.map.corners[2]:
+                    xgrid, ygrid = self.field.get_xypoint(lat, lons[i])
                     if xgrid > 0 and ygrid > 0:
                         data_value = self.field.values()[xgrid, ygrid]
                         if (not isnan(data_value)) and (data_value != 0.):

--- a/adb_graphics/figures/maps.py
+++ b/adb_graphics/figures/maps.py
@@ -10,6 +10,7 @@ barbs, and descriptive annotation.
 
 from functools import lru_cache
 
+from math import isnan
 import matplotlib.pyplot as plt
 import matplotlib.image as mpimg
 import matplotlib.offsetbox as mpob
@@ -332,6 +333,16 @@ class DataMap():
         add_wind = self.field.vspec.get('wind', False)
         if add_wind:
             self._wind_barbs(add_wind)
+
+        # Add field values at airports
+        lats = self.map.airports[:, 0]
+        lons = self.map.airports[:, 1]
+        x, y = self.map.m(lons, lats)
+        for i, lat in enumerate(lats):
+            xgrid, ygrid = self.field.get_xypoint(lats[i], lons[i])
+            data_value = self.field.values()[xgrid,ygrid]
+            if not isnan(data_value):
+                ax.annotate(f"{data_value:.0f}", xy=(x[i], y[i]), fontsize=10)
 
         # Finish with the title
         self._title()

--- a/adb_graphics/specs.py
+++ b/adb_graphics/specs.py
@@ -380,16 +380,39 @@ class VarSpec(abc.ABC):
     @lru_cache()
     def tsfc_colors(self) -> np.ndarray:
 
-        ''' Default color map for Surface Temperature '''
+        ''' Default color map for Surface Temperature '''  # WeatherBell scheme
 
-        temp1 = cm.get_cmap('PRGn_r', 30)(range(0, 30))
-        temp2 = cm.get_cmap('PiYG', 20)(range(0, 9))
-        temp3 = cm.get_cmap('bwr_r', 20)(range(10, 17))
-        temp4 = cm.get_cmap('RdYlBu_r', 20)(range(0, 19))
-        temp5 = cm.get_cmap('Reds_r', 15)(range(0, 14))
-        temp6 = cm.get_cmap('Greys', 15)(range(0, 14))
+        temp1 = cm.get_cmap('cool_r', 15)(range(0, 15))
+        temp2 = cm.get_cmap('BuGn', 12)(range(4, 12))
+        temp3 = cm.get_cmap('Greens_r', 8)(range(0, 8))
+        temp4 = cm.get_cmap('RdPu_r', 15)(range(0, 15))
+        temp5 = cm.get_cmap('BuPu', 10)(range(0, 9))
+        temp6 = cm.get_cmap('RdYlBu_r', 20)(range(2, 20))
+        temp7 = cm.get_cmap('RdYlGn', 20)(range(0, 20))
 
-        return np.concatenate((temp1, temp2, temp3, temp4, temp5, temp6))
+        return np.concatenate((temp1, temp2, temp3, temp4, temp5, temp6, temp7))
+
+#        ''' Default color map for Surface Temperature '''  # Pivotal Wx scheme
+#
+#        temp1 = cm.get_cmap('PRGn_r', 30)(range(0, 30))
+#        temp2 = cm.get_cmap('PiYG', 20)(range(0, 9))
+#        temp3 = cm.get_cmap('bwr_r', 20)(range(10, 17))
+#        temp4 = cm.get_cmap('RdYlBu_r', 25)(range(3, 22))
+#        temp5 = cm.get_cmap('Reds_r', 16)(range(1, 15))
+#        temp6 = cm.get_cmap('Greys', 15)(range(0, 14))
+#
+#        return np.concatenate((temp1, temp2, temp3, temp4, temp5, temp6))
+
+#        ''' Default color map for Surface Temperature '''  # Tropical Tidbits scheme
+#
+#        temp1 = cm.get_cmap('PiYG', 40)(range(0, 19))
+#        temp2 = cm.get_cmap('PRGn_r', 10)(range(4, 9))
+#        temp3 = cm.get_cmap('PuOr_r', 10)(range(1, 6))
+#        temp4 = cm.get_cmap('Blues', 5)(range(0, 5))
+#        temp5 = cm.get_cmap('jet', 40)(range(0, 39))
+#        temp6 = cm.get_cmap('RdGy', 20)(range(0, 19))
+#
+#        return np.concatenate((temp1, temp2, temp3, temp4, temp5, temp6))
 
     @property
     @lru_cache()

--- a/adb_graphics/specs.py
+++ b/adb_graphics/specs.py
@@ -363,6 +363,8 @@ class VarSpec(abc.ABC):
 
         ncar = cm.get_cmap(self.vspec.get('cmap'), 128) \
                           ([88, 83, 80, 70, 50, 25, 20, 15])
+        return np.concatenate((grays, ncar))
+
         return ncar
 
     @property
@@ -371,8 +373,11 @@ class VarSpec(abc.ABC):
 
         ''' Default color map for Temperature '''
 
-        ncolors = len(self.clevs)
-        return cm.get_cmap(self.vspec.get('cmap', 'jet'), ncolors)(range(ncolors))
+        temp1 = cm.get_cmap('PRGn_r', 35)(range(0, 35))
+        temp2 = cm.get_cmap('nipy_spectral', 50)(range(3, 48))
+        temp3 = cm.get_cmap('Reds_r', 20)(range(3, 19))
+
+        return np.concatenate((temp1, temp2, temp3))
 
     @property
     @lru_cache()

--- a/adb_graphics/specs.py
+++ b/adb_graphics/specs.py
@@ -363,8 +363,6 @@ class VarSpec(abc.ABC):
 
         ncar = cm.get_cmap(self.vspec.get('cmap'), 128) \
                           ([88, 83, 80, 70, 50, 25, 20, 15])
-        return np.concatenate((grays, ncar))
-
         return ncar
 
     @property
@@ -380,25 +378,8 @@ class VarSpec(abc.ABC):
     @lru_cache()
     def tsfc_colors(self) -> np.ndarray:
 
-#        ''' Default color map for Surface Temperature '''  # GSL NCL scheme
-#
-#        temp1 = cm.get_cmap('autumn_r', 20)(range(0, 10))
-#        temp2 = cm.get_cmap('Greys_r', 10)(range(2, 7))
-#        temp3 = cm.get_cmap('hsv_r', 70)(range(0, 38))
-#        temp4 = cm.get_cmap('hsv_r', 70)(range(48, 70))
-#        temp5 = cm.get_cmap('gist_ncar', 55)(range(40, 55))
-#
-#        return np.concatenate((temp1, temp2, temp3, temp4, temp5))
+        ''' Default color map for Surface Temperature '''  # WeatherBell-inspired scheme
 
-        ''' Default color map for Surface Temperature '''  # WeatherBell scheme
-
-#        temp1 = cm.get_cmap('cool_r', 15)(range(0, 15))
-#        temp2 = cm.get_cmap('BuGn', 12)(range(4, 12))
-#        temp3 = cm.get_cmap('Greens_r', 8)(range(0, 8))
-#        temp4 = cm.get_cmap('RdPu_r', 15)(range(0, 15))
-#        temp5 = cm.get_cmap('BuPu', 10)(range(0, 9))
-#        temp6 = cm.get_cmap('RdYlBu_r', 20)(range(2, 20))
-#        temp7 = cm.get_cmap('RdYlGn', 20)(range(0, 20))
         temp1 = cm.get_cmap('cool_r', 8)(range(0, 8))
         temp2 = cm.get_cmap('BuGn', 6)(range(2, 6))
         temp3 = cm.get_cmap('Greens_r', 4)(range(0, 4))
@@ -407,30 +388,7 @@ class VarSpec(abc.ABC):
         temp6 = cm.get_cmap('RdYlBu_r', 10)(range(1, 10))
         temp7 = cm.get_cmap('RdYlGn', 10)(range(0, 10))
 
-
         return np.concatenate((temp1, temp2, temp3, temp4, temp5, temp6, temp7))
-
-#        ''' Default color map for Surface Temperature '''  # Pivotal Wx scheme
-#
-#        temp1 = cm.get_cmap('PRGn_r', 30)(range(0, 30))
-#        temp2 = cm.get_cmap('PiYG', 20)(range(0, 9))
-#        temp3 = cm.get_cmap('bwr_r', 20)(range(10, 17))
-#        temp4 = cm.get_cmap('RdYlBu_r', 25)(range(3, 22))
-#        temp5 = cm.get_cmap('Reds_r', 16)(range(1, 15))
-#        temp6 = cm.get_cmap('Greys', 15)(range(0, 14))
-#
-#        return np.concatenate((temp1, temp2, temp3, temp4, temp5, temp6))
-#
-#        ''' Default color map for Surface Temperature '''  # Tropical Tidbits scheme
-#
-#        temp1 = cm.get_cmap('PiYG', 40)(range(0, 19))
-#        temp2 = cm.get_cmap('PRGn_r', 10)(range(4, 9))
-#        temp3 = cm.get_cmap('PuOr_r', 10)(range(1, 6))
-#        temp4 = cm.get_cmap('Blues', 5)(range(0, 5))
-#        temp5 = cm.get_cmap('jet', 40)(range(0, 39))
-#        temp6 = cm.get_cmap('RdGy', 20)(range(0, 19))
-#
-#        return np.concatenate((temp1, temp2, temp3, temp4, temp5, temp6))
 
     @property
     @lru_cache()

--- a/adb_graphics/specs.py
+++ b/adb_graphics/specs.py
@@ -380,17 +380,27 @@ class VarSpec(abc.ABC):
     @lru_cache()
     def tsfc_colors(self) -> np.ndarray:
 
-        ''' Default color map for Surface Temperature '''  # WeatherBell scheme
+        ''' Default color map for Surface Temperature '''  # GSL NCL scheme
 
-        temp1 = cm.get_cmap('cool_r', 15)(range(0, 15))
-        temp2 = cm.get_cmap('BuGn', 12)(range(4, 12))
-        temp3 = cm.get_cmap('Greens_r', 8)(range(0, 8))
-        temp4 = cm.get_cmap('RdPu_r', 15)(range(0, 15))
-        temp5 = cm.get_cmap('BuPu', 10)(range(0, 9))
-        temp6 = cm.get_cmap('RdYlBu_r', 20)(range(2, 20))
-        temp7 = cm.get_cmap('RdYlGn', 20)(range(0, 20))
+        temp1 = cm.get_cmap('autumn_r', 20)(range(0, 10))
+        temp2 = cm.get_cmap('Greys_r', 10)(range(2, 7))
+        temp3 = cm.get_cmap('hsv_r', 70)(range(0, 38))
+        temp4 = cm.get_cmap('hsv_r', 70)(range(48, 70))
+        temp5 = cm.get_cmap('gist_ncar', 55)(range(40, 55))
 
-        return np.concatenate((temp1, temp2, temp3, temp4, temp5, temp6, temp7))
+        return np.concatenate((temp1, temp2, temp3, temp4, temp5))
+
+#        ''' Default color map for Surface Temperature '''  # WeatherBell scheme
+#
+#        temp1 = cm.get_cmap('cool_r', 15)(range(0, 15))
+#        temp2 = cm.get_cmap('BuGn', 12)(range(4, 12))
+#        temp3 = cm.get_cmap('Greens_r', 8)(range(0, 8))
+#        temp4 = cm.get_cmap('RdPu_r', 15)(range(0, 15))
+#        temp5 = cm.get_cmap('BuPu', 10)(range(0, 9))
+#        temp6 = cm.get_cmap('RdYlBu_r', 20)(range(2, 20))
+#        temp7 = cm.get_cmap('RdYlGn', 20)(range(0, 20))
+#
+#        return np.concatenate((temp1, temp2, temp3, temp4, temp5, temp6, temp7))
 
 #        ''' Default color map for Surface Temperature '''  # Pivotal Wx scheme
 #

--- a/adb_graphics/specs.py
+++ b/adb_graphics/specs.py
@@ -380,18 +380,18 @@ class VarSpec(abc.ABC):
     @lru_cache()
     def tsfc_colors(self) -> np.ndarray:
 
-        ''' Default color map for Surface Temperature '''  # GSL NCL scheme
-
-        temp1 = cm.get_cmap('autumn_r', 20)(range(0, 10))
-        temp2 = cm.get_cmap('Greys_r', 10)(range(2, 7))
-        temp3 = cm.get_cmap('hsv_r', 70)(range(0, 38))
-        temp4 = cm.get_cmap('hsv_r', 70)(range(48, 70))
-        temp5 = cm.get_cmap('gist_ncar', 55)(range(40, 55))
-
-        return np.concatenate((temp1, temp2, temp3, temp4, temp5))
-
-#        ''' Default color map for Surface Temperature '''  # WeatherBell scheme
+#        ''' Default color map for Surface Temperature '''  # GSL NCL scheme
 #
+#        temp1 = cm.get_cmap('autumn_r', 20)(range(0, 10))
+#        temp2 = cm.get_cmap('Greys_r', 10)(range(2, 7))
+#        temp3 = cm.get_cmap('hsv_r', 70)(range(0, 38))
+#        temp4 = cm.get_cmap('hsv_r', 70)(range(48, 70))
+#        temp5 = cm.get_cmap('gist_ncar', 55)(range(40, 55))
+#
+#        return np.concatenate((temp1, temp2, temp3, temp4, temp5))
+
+        ''' Default color map for Surface Temperature '''  # WeatherBell scheme
+
 #        temp1 = cm.get_cmap('cool_r', 15)(range(0, 15))
 #        temp2 = cm.get_cmap('BuGn', 12)(range(4, 12))
 #        temp3 = cm.get_cmap('Greens_r', 8)(range(0, 8))
@@ -399,8 +399,16 @@ class VarSpec(abc.ABC):
 #        temp5 = cm.get_cmap('BuPu', 10)(range(0, 9))
 #        temp6 = cm.get_cmap('RdYlBu_r', 20)(range(2, 20))
 #        temp7 = cm.get_cmap('RdYlGn', 20)(range(0, 20))
-#
-#        return np.concatenate((temp1, temp2, temp3, temp4, temp5, temp6, temp7))
+        temp1 = cm.get_cmap('cool_r', 8)(range(0, 8))
+        temp2 = cm.get_cmap('BuGn', 6)(range(2, 6))
+        temp3 = cm.get_cmap('Greens_r', 4)(range(0, 4))
+        temp4 = cm.get_cmap('RdPu_r', 8)(range(0, 8))
+        temp5 = cm.get_cmap('BuPu', 5)(range(0, 4))
+        temp6 = cm.get_cmap('RdYlBu_r', 10)(range(1, 10))
+        temp7 = cm.get_cmap('RdYlGn', 10)(range(0, 10))
+
+
+        return np.concatenate((temp1, temp2, temp3, temp4, temp5, temp6, temp7))
 
 #        ''' Default color map for Surface Temperature '''  # Pivotal Wx scheme
 #
@@ -412,7 +420,7 @@ class VarSpec(abc.ABC):
 #        temp6 = cm.get_cmap('Greys', 15)(range(0, 14))
 #
 #        return np.concatenate((temp1, temp2, temp3, temp4, temp5, temp6))
-
+#
 #        ''' Default color map for Surface Temperature '''  # Tropical Tidbits scheme
 #
 #        temp1 = cm.get_cmap('PiYG', 40)(range(0, 19))

--- a/adb_graphics/specs.py
+++ b/adb_graphics/specs.py
@@ -371,13 +371,25 @@ class VarSpec(abc.ABC):
     @lru_cache()
     def t_colors(self) -> np.ndarray:
 
-        ''' Default color map for Temperature '''
+        ''' Default color map for Upper-Air Temperature '''
 
-        temp1 = cm.get_cmap('PRGn_r', 35)(range(0, 35))
-        temp2 = cm.get_cmap('nipy_spectral', 50)(range(3, 48))
-        temp3 = cm.get_cmap('Reds_r', 20)(range(3, 19))
+        ncolors = len(self.clevs)
+        return cm.get_cmap(self.vspec.get('cmap', 'jet'), ncolors)(range(ncolors))
 
-        return np.concatenate((temp1, temp2, temp3))
+    @property
+    @lru_cache()
+    def tsfc_colors(self) -> np.ndarray:
+
+        ''' Default color map for Surface Temperature '''
+
+        temp1 = cm.get_cmap('PRGn_r', 30)(range(0, 30))
+        temp2 = cm.get_cmap('PiYG', 20)(range(0, 9))
+        temp3 = cm.get_cmap('bwr_r', 20)(range(10, 17))
+        temp4 = cm.get_cmap('RdYlBu_r', 20)(range(0, 19))
+        temp5 = cm.get_cmap('Reds_r', 15)(range(0, 14))
+        temp6 = cm.get_cmap('Greys', 15)(range(0, 14))
+
+        return np.concatenate((temp1, temp2, temp3, temp4, temp5, temp6))
 
     @property
     @lru_cache()

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -127,6 +127,8 @@ class TestDefaultSpecs():
 
         return {
             'accumulate': self.is_bool,
+            'annotate': self.is_bool,
+            'annotate_decimal': self.is_int,
             'clevs': self.is_a_clev,
             'cmap': self.is_a_cmap,
             'colors': self.is_a_color,

--- a/tests/test_grib.py
+++ b/tests/test_grib.py
@@ -101,7 +101,7 @@ def test_profileData(natfile):
                                    short_name='temp',
                                    )
 
-    assert isinstance(profile.get_xypoint(), tuple)
+    assert isinstance(profile.get_xypoint(40., -100.), tuple)
     assert isinstance(profile.values(), xarray.DataArray)
 
     # The values should return a single number (0) or a 1D array (1)


### PR DESCRIPTION
This PR is to change the default color table for 2m and sfc Temp, and add annotated values at airports (default is False, only set for 2m T here).

The version failed one pytest step and 2 pylint (unused variable and too-many-variables), the latter was disabled.

Some tweaking of the colors may still be needed, although this is not the final color table so might wait on that step.

Sample 2m T plot:
<img width="847" alt="Screen Shot 2021-05-19 at 4 10 54 PM" src="https://user-images.githubusercontent.com/56739562/118891149-e1683f00-b8bc-11eb-908e-f7af1c4d4524.png">
