### PR TITLE
change map resolution to reduce zip file size.

### DIFF
--- a/create_graphics.py
+++ b/create_graphics.py
@@ -489,7 +489,7 @@ def parallel_skewt(cla, fhr, ds, site, workdir):
     plt.savefig(
         png_path,
         bbox_inches='tight',
-        dpi='figure',
+        dpi=72,
         format='png',
         orientation='landscape',
         )


### PR DESCRIPTION
This is a one-word change in create_graphics.py, to reduce the plot sizes and allow for smaller overall zip file size.  

passed both pylint and pytest.

adding sample plots, not sure how they'll look in GitHub (each display software behaves differently).  On the Web pages, expecting the plots to be reduced in size with little loss of resolution at the new size.
<img width="997" alt="Screen Shot 2021-05-24 at 11 09 14 AM" src="https://user-images.githubusercontent.com/56739562/119386992-88662580-bc85-11eb-8e50-130c968f63ea.png">
<img width="725" alt="Screen Shot 2021-05-24 at 11 09 26 AM" src="https://user-images.githubusercontent.com/56739562/119387009-8dc37000-bc85-11eb-9de2-a76328ca2cf9.png">
