### PR TITLE
change map resolution instead of skewTs.

### DIFF
--- a/create_graphics.py
+++ b/create_graphics.py
@@ -449,7 +449,7 @@ def parallel_maps(cla, fhr, ds, level, model, spec, variable, workdir,
     plt.savefig(
         png_path,
         bbox_inches='tight',
-        dpi='figure',
+        dpi=72,
         format='png',
         orientation='landscape',
         )
@@ -489,7 +489,7 @@ def parallel_skewt(cla, fhr, ds, site, workdir):
     plt.savefig(
         png_path,
         bbox_inches='tight',
-        dpi=72,
+        dpi='figure',
         format='png',
         orientation='landscape',
         )


### PR DESCRIPTION
In previous PR, I accidentally left the maps resolution as is and changed the skewT resolution in the final version, instead of the other way around.  This corrects that with two lines changed in create_graphics.py.

---------------------------------

This is a one-word change in create_graphics.py, to reduce the plot sizes and allow for smaller overall zip file size.

passed both pylint and pytest.

adding sample plots, not sure how they'll look in GitHub (each display software behaves differently). On the Web pages, expecting the plots to be reduced in size with little loss of resolution at the new size.
Screen Shot 2021-05-24 at 11 09 14 AM
Screen Shot 2021-05-24 at 11 09 26 AM