### PR TITLE
add optimize flag for png plot sizes

### DIFF
--- a/create_graphics.py
+++ b/create_graphics.py
@@ -452,6 +452,7 @@ def parallel_maps(cla, fhr, ds, level, model, spec, variable, workdir,
         dpi=72,
         format='png',
         orientation='landscape',
+        pil_kwargs={'optimize': True},
         )
 
     plt.close()


### PR DESCRIPTION
one extra flag in create_graphics:parallel_maps:plt.savefig, to optimize the PNG plot file sizes.

Test's show about 2-3% lower files sizes.  No change in plot images.

Passed pylint and pytest.

Sample plot size change:
ceil_full_f000.png            225 kB  --> 219 kB
temp_full_2m_f000.png   418 kB --> 410 kB