### PR TITLE
Fixes for accumulated precip

### DIFF
--- a/adb_graphics/datahandler/gribfile.py
+++ b/adb_graphics/datahandler/gribfile.py
@@ -108,7 +108,7 @@ class GribFiles():
                     ]
                 needs_renaming = var.split('_')[0] in odd_variables
                 contains_suffix = [suf for suf in special_suffixes if suf in
-                        suffix and '1h' not in suffix]
+                                   suffix and '1h' not in suffix]
                 if contains_suffix and needs_renaming:
                     ret[var] = var.replace(suffix, contains_suffix[0])
 

--- a/adb_graphics/default_specs.yml
+++ b/adb_graphics/default_specs.yml
@@ -96,7 +96,7 @@ acfrozr: # Run Total Graupel
     clevs: [0.002, 0.01, 0.05, 0.1, 0.25, 0.5, 0.75, 1, 2]
     cmap: gist_ncar
     colors: pcp_colors
-    ncl_name: FROZR_P8_L1_GLC0_acc{fhr}h
+    ncl_name: FROZR_P8_L1_GLC0_acc
     ticks: 0
     title: Total Graupel (Sleet)
     transform: conversions.kgm2_to_in
@@ -111,7 +111,7 @@ acpcp: # Accumulated run total precipitation
     clevs: [0.01, 0.1, 0.25, 0.5, 1, 2, 3, 5, 10, 15, 20, 40]
     cmap: gist_ncar
     colors: rainbow12_colors
-    ncl_name: APCP_P8_L1_{grid}_acc{fhr}h
+    ncl_name: APCP_P8_L1_{grid}_acc
     ticks: 0
     transform: conversions.kgm2_to_in
     unit: in
@@ -130,7 +130,7 @@ acsnw: # Run Total Accumulated Snow Using 10:1 Ratio
     clevs: [0.01, 0.1, 1, 2, 3, 4, 6, 8, 10, 12, 18, 24]
     cmap: gist_ncar
     colors: snow_colors
-    ncl_name: WEASD_P8_L1_{grid}_acc{fhr}h
+    ncl_name: WEASD_P8_L1_{grid}_acc
     ticks: 0
     title: Run-Total Accumulated Snow Using 10:1 Ratio
     transform: [conversions.kgm2_to_in, conversions.weasd_to_1hsnw]
@@ -675,7 +675,7 @@ ltg3: # Lightning Threat (LTG1 ... LTG2)
     colors: cref_colors
     ncl_name: LTNG_P0_L10_{grid}
     ticks: 0
-    title: Lightning Threat (comb of LTG1 and LTG2)
+    title: Lightning Threat
     unit: flashes / km^2 / 5 min
 mref: # Maximum reflectivity for past hour at 1 km AGL
   sfc:
@@ -763,7 +763,7 @@ ptyp: # Hourly total precipitation
         labels: Ice Pellets
         levels: [0, 1]
         linewidths: 0.2
-    ncl_name: APCP_P8_L1_GLC0_acc1h
+    ncl_name: APCP_P8_L1_{grid}_acc1h
     ticks: 0
     title: 1 hr Total Precip, Precip Type
     transform: conversions.kgm2_to_in

--- a/adb_graphics/figures/maps.py
+++ b/adb_graphics/figures/maps.py
@@ -396,6 +396,7 @@ class DataMap():
 
         # Create a descriptor string for the first hatched field, if one exists
         contoured = []
+        contoured_units = []
         not_labeled = [f.short_name]
         if self.hatch_fields:
             cf = self.hatch_fields[0]
@@ -409,9 +410,12 @@ class DataMap():
             for cf in self.contour_fields:
                 if cf.short_name not in not_labeled:
                     title = cf.vspec.get('title', cf.field.long_name)
-                    contoured.append(f'{title} ({cf.units}, contoured)')
+                    contoured.append(f'{title}')
+                    contoured_units.append(f'{cf.units}')
 
         contoured = ', '.join(contoured)
+        if contoured_units:
+            contoured = f"{contoured} ({', '.join(contoured_units)}; contoured)"
 
         # Analysis time (top) and forecast hour (bottom) on the left
 
@@ -424,6 +428,7 @@ class DataMap():
         # Atmospheric level and unit in the high center
         level, lev_unit = f.numeric_level(index_match=False)
         if not f.vspec.get('title'):
+            level = level if not isinstance(level, list) else level[0]
             plt.title(f"{level} {lev_unit}", position=(0.5, 1.04), fontsize=18)
 
         # Two lines for shaded data (top), and contoured data (bottom)

--- a/environment.yml
+++ b/environment.yml
@@ -12,3 +12,4 @@ dependencies:
   - pylint=2.4*
   - pytest=6.1*
   - pyyaml=5.3.1
+  - xarray=0.15.1

--- a/environment.yml
+++ b/environment.yml
@@ -12,4 +12,3 @@ dependencies:
   - pylint=2.4*
   - pytest=6.1*
   - pyyaml=5.3.1
-  - xarray=0.15.1


### PR DESCRIPTION
This set of changes renames the variables in RAP/HRRR/RRFS that include the forecast in the accumulated variables to only be subscripted with "acc". This allows xarray to accumulate them as a single variable. It should fix the absence of the plots on the web.

I also changed the way longer lists of contoured variables were plotted so that the titles wouldn't as often run long. Here's an example of 1hr total precip (from two different times).

Update:
![image](https://user-images.githubusercontent.com/56881914/121567201-89b08580-c9db-11eb-892a-752671ddc459.png)

Current:
![image](https://user-images.githubusercontent.com/56881914/121567309-a77dea80-c9db-11eb-9aaa-9ca6b92108aa.png)

