### PR TITLE
Fix to check for & remove existing zip files

### DIFF
--- a/create_graphics.py
+++ b/create_graphics.py
@@ -510,6 +510,8 @@ def graphics_driver(cla):
 
     '''
 
+    # pylint: disable=too-many-branches, too-many-locals
+
     # Create an empty zip file
     if cla.zip_dir:
         zipfiles = {}
@@ -519,8 +521,8 @@ def graphics_driver(cla):
             tile_zip_file = os.path.join(tile_zip_dir, 'files.zip')
             print(f"checking for {tile_zip_file}")
             if os.path.isfile(tile_zip_file):
-              os.remove(tile_zip_file)
-              print(f"{tile_zip_file} found and removed")
+                os.remove(tile_zip_file)
+                print(f"{tile_zip_file} found and removed")
             os.makedirs(tile_zip_dir, exist_ok=True)
             zipfiles[tile] = tile_zip_file
 

--- a/create_graphics.py
+++ b/create_graphics.py
@@ -516,8 +516,13 @@ def graphics_driver(cla):
         tiles = cla.tiles if cla.graphic_type == "maps" else ['skewt']
         for tile in tiles:
             tile_zip_dir = os.path.join(cla.zip_dir, tile)
+            tile_zip_file = os.path.join(tile_zip_dir, 'files.zip')
+            print(f"checking for {tile_zip_file}")
+            if os.path.isfile(tile_zip_file):
+              os.remove(tile_zip_file)
+              print(f"{tile_zip_file} found and removed")
             os.makedirs(tile_zip_dir, exist_ok=True)
-            zipfiles[tile] = os.path.join(tile_zip_dir, 'files.zip')
+            zipfiles[tile] = tile_zip_file
 
     fcst_hours = copy.deepcopy(cla.fcst_hour)
 


### PR DESCRIPTION
When a run needs to be restarted, new files get appended to existing zip files from the previous run, despite having the same names. This fix checks for existing zip files and removes them if present.