### PR TITLE
Adding HRRR Smoke Products

### DIFF
--- a/adb_graphics/conversions.py
+++ b/adb_graphics/conversions.py
@@ -72,6 +72,12 @@ def percent(field: np.ndarray, **kwargs) -> np.ndarray:
 
     return np.asarray(field) * 100.
 
+def to_micro(field: np.ndarray, **kwargs) -> np.ndarray:
+
+    ''' Convert field to micro '''
+
+    return np.asarray(field) * 1E6
+
 def vvel_scale(field: np.ndarray, **kwargs) -> np.ndarray:
 
     ''' Scale vertical velocity for plotting  '''

--- a/adb_graphics/default_specs.yml
+++ b/adb_graphics/default_specs.yml
@@ -367,14 +367,14 @@ echotop: # Echo Top
     unit: kft
 firewx: # Fire Weather Index
   sfc:
-    clevs: [1, 100, 500, 1000, 1500, 2000, 2500, 3000, 3500, 4000, 4500, 5000]
+    clevs: [1, 500, 2500, 5000, 7500, 10000, 12500, 15000, 17500, 20000, 22500, 25000]
     cmap: gist_ncar
     colors: vort_colors
-    ncl_name: VIL_P0_L10_{grid}
+    ncl_name: VGTYP_P0_L1_{grid} # choosing one of the un-transformed values in the algorithm
     ticks: 0
-    title: Experimental Fire Weather Index
+    title: Hourly Fire Potential
     transform: fire_weather_index
-    unit: hPa m2 / s2
+    unit: $K^{0.61} m^{1.82} / s^{1.82}$
 flru: # Aviation Flight Rules
   sfc:
     clevs: [0.0, 1.0, 2.0, 3.0, 4.0]
@@ -625,9 +625,6 @@ icmr: # Ice Water Mixing Ratio
         - ICMR_P0_L105_{grid}
         - CIMIXR_P0_L105_{grid}
       prs: ICMR_P0_L100_{grid}
-land: # Land Cover
-  sfc:
-    ncl_name:  LAND_P0_L1_{grid}
 lcl: # Lifted condensation level
   sfc: &lcl
     clevs: !!python/object/apply:numpy.arange [0, 5000, 250]

--- a/adb_graphics/default_specs.yml
+++ b/adb_graphics/default_specs.yml
@@ -372,7 +372,7 @@ firewx: # Fire Weather Index
     colors: vort_colors
     ncl_name: VGTYP_P0_L1_{grid} # choosing one of the un-transformed values in the algorithm
     ticks: 0
-    title: Hourly Fire Potential
+    title: Hourly Wildfire Potential
     transform: fire_weather_index
     unit: $K^{0.61} m^{1.82} / s^{1.82}$
 flru: # Aviation Flight Rules

--- a/adb_graphics/default_specs.yml
+++ b/adb_graphics/default_specs.yml
@@ -640,7 +640,7 @@ lhtfl: # Latent Heat Net Flux
     ncl_name: LHTFL_P0_L1_{grid}
     ticks: 0
     title: Latent Heat Net Flux
-    unit: W/m^2
+    unit: $W/m^2$
 li: # Lifted Index
   best: &lifted_index
     clevs: !!python/object/apply:numpy.arange [-15, 16]
@@ -676,7 +676,15 @@ ltg3: # Lightning Threat (LTG1 ... LTG2)
     ncl_name: LTNG_P0_L10_{grid}
     ticks: 0
     title: Lightning Threat
-    unit: flashes / km^2 / 5 min
+    unit: $flashes / km^2 / 5 min$
+mfrp: # Fire radiative power
+  sfc:
+    clevs: [0, 10, 25, 50, 100, 250]
+    colors: fire_power_colors
+    ncl_name: CFNSF_P0_L1_{grid}
+    ticks: 0
+    title: Fire Radiative Power
+    unit: MW
 mref: # Maximum reflectivity for past hour at 1 km AGL
   sfc:
     <<: *refl
@@ -877,7 +885,7 @@ rvil: # Radar-derived Vertically Integrated Liquid
       rrfs: VIL_P0_L200_{grid}
     ticks: 0
     title: Radar-derived Vertically Integrated Liquid
-    unit: kg/m^2
+    unit: $kg/m^2$
 rwmr: # Rain Mixing Ratio
   ua:
     ncl_name:
@@ -915,7 +923,7 @@ shtfl: # Sensible Heat Net Flux
     ncl_name: SHTFL_P0_L1_{grid}
     ticks: 0
     title: Sensible Heat Net Flux
-    unit: W/m^2
+    unit: $W/m^2$
 slw: # Supercooled Liquid Water
   sfc:
     clevs: [0.05, 0.1, 0.2, .3, .4, .5, .75, 1., 1.25, 1.5, 2., 3., 4., 5., 6.]
@@ -925,7 +933,7 @@ slw: # Supercooled Liquid Water
     ticks: 0
     title: Supercooled Liquid Water
     transform: supercooled_liquid_water
-    unit: kg/m^2
+    unit: $kg/m^2$
 snmr: # Snow Mixing Ratio
   ua:
     ncl_name:
@@ -1028,7 +1036,7 @@ solar: # Incoming Solar Radiation
     ncl_name: DSWRF_P0_L1_{grid}
     ticks: 0
     title: Incoming Solar Radiation
-    unit: W/m^2
+    unit: $W/m^2$
 sphum: # Specific humidity
   ua:
     ncl_name: SPFH_P0_L105_{grid}
@@ -1162,6 +1170,23 @@ totp: # Hourly total precipitation
         linestyles: dashed
     ncl_name: APCP_P8_L1_{grid}_acc1h
     title: 1 hr Total Precip
+trc1:
+  int:
+    clevs: [1, 4, 7, 11, 15, 20, 25, 30, 40, 50, 75, 150, 250, 500]
+    colors: smoke_colors
+    ncl_name: COLMD_P0_L200_{grid}
+    ticks: 0
+    title: Vertically Integrated Smoke
+    transform: conversions.to_micro
+    unit: $mg/m^2$
+  sfc:
+    clevs: [1, 2, 4, 6, 8, 12, 16, 20, 25, 30, 40, 60, 100, 200]
+    colors: smoke_colors
+    ncl_name: MASSDEN_P0_L103_{grid}
+    title: Near-Surface Smoke
+    ticks: 0
+    unit: $\mu g/m^2$
+    wind: 10m
 u:
   10m: &agl_uwind
     ncl_name: UGRD_P0_L103_{grid}
@@ -1189,7 +1214,7 @@ ulwrf: # Upward Longwave Radiation Flux
     ncl_name: ULWRF_P0_L1_{grid}
     ticks: 0
     title: Upward Longwave Radiation Flux, Surface
-    unit: W/m^2
+    unit: $W/m^2$
   top: # Nominal top of atmosphere
     clevs: !!python/object/apply:numpy.arange [80, 341, 2]
     cmap: ir_rgbv_r
@@ -1197,7 +1222,7 @@ ulwrf: # Upward Longwave Radiation Flux
     ncl_name: ULWRF_P0_L8_{grid}
     ticks: 20
     title: Outgoing Longwave Radiation Flux, Top of Atmosphere
-    unit: W/m^2
+    unit: $W/m^2$
 uswrf: # Upward Shortwave Radiation Flux
   sfc:
     <<: *radiation_flux

--- a/adb_graphics/default_specs.yml
+++ b/adb_graphics/default_specs.yml
@@ -1185,7 +1185,7 @@ trc1:
     ncl_name: MASSDEN_P0_L103_{grid}
     title: Near-Surface Smoke
     ticks: 0
-    unit: $\mu g/m^2$
+    unit: $\mu g/m^3$
     wind: 10m
 u:
   10m: &agl_uwind

--- a/adb_graphics/specs.py
+++ b/adb_graphics/specs.py
@@ -9,6 +9,7 @@ import abc
 from itertools import chain
 from functools import lru_cache
 from matplotlib import cm
+from matplotlib import colors as mpcolors
 import numpy as np
 import yaml
 from metpy.plots import ctables
@@ -112,6 +113,15 @@ class VarSpec(abc.ABC):
         return ctable
 
     @property
+    @lru_cache()
+    def fire_power_colors(self) -> np.ndarray:
+
+        ''' Default color map for fire power plot. '''
+
+        blues = cm.get_cmap('Blues', 3)(range(3))
+        green_orange = cm.get_cmap('RdYlGn_r', 10)([1, 7, 8, 9])
+        return np.concatenate((blues, green_orange))
+
     @lru_cache()
     def flru_colors(self) -> np.ndarray:
 
@@ -324,6 +334,18 @@ class VarSpec(abc.ABC):
                           (range(5, 15))
         ctable[9] = [1, 1, 1, 1]
         return ctable
+
+    @property
+    @lru_cache()
+    def smoke_colors(self) -> np.ndarray:
+
+        ''' Default color map for smoke plots. '''
+
+        blues = cm.get_cmap('Blues', 6)(range(5))
+        green_yellow_red = cm.get_cmap('RdYlGn_r', 18)([1, 3, 5, 9, 12, 13, 14, 16, 18])
+        purple = np.array([mpcolors.to_rgba('xkcd:vivid purple')])
+        return np.concatenate((blues, green_yellow_red, purple))
+
 
     @property
     @lru_cache()

--- a/image_lists/hrrr_smoke.yml
+++ b/image_lists/hrrr_smoke.yml
@@ -1,8 +1,8 @@
 hourly:
   model: hrrr
   variables:
-    #    fwi:
-    #      - sfc
+    firewx:
+      - sfc
     gust:
       - 10m
     hpbl:

--- a/image_lists/hrrr_smoke.yml
+++ b/image_lists/hrrr_smoke.yml
@@ -1,0 +1,23 @@
+hourly:
+  model: hrrr
+  variables:
+    #    fwi:
+    #      - sfc
+    gust:
+      - 10m
+    hpbl:
+      - sfc
+    mfrp:
+      - sfc
+    temp:
+      - 2m
+    totp:
+      - sfc
+    trc1:
+      - sfc
+      - int
+    vis:
+      - sfc
+    wspeed:
+      - 80m
+

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -358,6 +358,7 @@ class TestDefaultSpecs():
             'esbl',    # ???
             'esblmn',  # ???
             'high',    # high clouds
+            'int',     # vertical integral
             'low',     # low clouds
             'max',     # maximum in column
             'maxsfc',  # max surface value


### PR DESCRIPTION
This batch of graphics adds the list for HRRR Smoke graphics, and sets up the specs for new fields (except for fire weather index). I have already fixed the units on the Near-sfc Smoke plot, but did not regenerate the figures.

I've also modified a few units to use Latex interpretation for nicer display of titles.

Examples of new graphics:


![image](https://user-images.githubusercontent.com/56881914/124618886-2d0f8180-de46-11eb-8413-58f4185210e1.png)
![image](https://user-images.githubusercontent.com/56881914/124618731-081b0e80-de46-11eb-978c-fb0b011e8801.png)

![image](https://user-images.githubusercontent.com/56881914/124618758-0e10ef80-de46-11eb-88ec-330aa215aa33.png)
![image](https://user-images.githubusercontent.com/56881914/124618776-12d5a380-de46-11eb-9a8c-8c5eeea70b7b.png)

![image](https://user-images.githubusercontent.com/56881914/124618789-1701c100-de46-11eb-9cba-7eb10432eacc.png)
![image](https://user-images.githubusercontent.com/56881914/124618989-43b5d880-de46-11eb-92b3-da0c7f767930.png)


Example of new unit formatting:
![image](https://user-images.githubusercontent.com/56881914/124620099-30573d00-de47-11eb-8ada-60b305fe9520.png)
