### PR TITLE
change visibility colors to approximate MDL

### DIFF
--- a/adb_graphics/default_specs.yml
+++ b/adb_graphics/default_specs.yml
@@ -1403,11 +1403,11 @@ vil: # Vertically Integrated Liquid
     title: Vertically Integrated Liquid
 vis: # Visibility
   sfc:
-    clevs: [0.0625, 0.125, 0.25, 0.5, 1, 1.5, 2, 3, 4, 5, 10, 30, 50]
+    clevs: !!python/object/apply:numpy.arange [0., 15., 0.1]
     cmap: gist_ncar
     colors: vis_colors
     ncl_name: VIS_P0_L1_{grid}
-    ticks: 0
+    ticks: -10
     title: Sfc Visibility
     transform: conversions.m_to_mi
     unit: mi

--- a/adb_graphics/specs.py
+++ b/adb_graphics/specs.py
@@ -428,6 +428,14 @@ class VarSpec(abc.ABC):
 
         ''' Default color map for Visibility '''
 
+        '''
+        section names are based on Aviation Flight Rule visibility categories
+        LIFR (Low Instrument Flight Rules) -- less than 1 mile
+        IFR (Instrument Flight Rules) -- 1 mile to less than 3 miles
+        MVFR (Marginal Visual Flight Rules) -- 3 to 5 miles
+        VFR (Visual Flight Rules) -- greater than 5 miles
+        '''
+        
         lifr = cm.get_cmap('RdPu_r', 20)(range(0, 11))
         ifr = cm.get_cmap('autumn', 30)(range(0, 30))
         mvfr = cm.get_cmap('Blues', 20)(range(10, 20))

--- a/adb_graphics/specs.py
+++ b/adb_graphics/specs.py
@@ -426,16 +426,15 @@ class VarSpec(abc.ABC):
     @lru_cache()
     def vis_colors(self) -> np.ndarray:
 
-        ''' Default color map for Visibility '''
+        ''' Default color map for Visibility
 
-        '''
         section names are based on Aviation Flight Rule visibility categories
         LIFR (Low Instrument Flight Rules) -- less than 1 mile
         IFR (Instrument Flight Rules) -- 1 mile to less than 3 miles
         MVFR (Marginal Visual Flight Rules) -- 3 to 5 miles
         VFR (Visual Flight Rules) -- greater than 5 miles
         '''
-        
+
         lifr = cm.get_cmap('RdPu_r', 20)(range(0, 11))
         ifr = cm.get_cmap('autumn', 30)(range(0, 30))
         mvfr = cm.get_cmap('Blues', 20)(range(10, 20))

--- a/adb_graphics/specs.py
+++ b/adb_graphics/specs.py
@@ -428,11 +428,13 @@ class VarSpec(abc.ABC):
 
         ''' Default color map for Visibility '''
 
-        grays = cm.get_cmap('Greys', 3)([1, 0])
-        ncar = cm.get_cmap(self.vspec.get('cmap'), 128) \
-                          ([15, 18, 20, 25, 50, 60, 70, 80, 85, 90, 100, 120])
+        lifr = cm.get_cmap('RdPu_r', 20)(range(0, 11))
+        ifr = cm.get_cmap('autumn', 30)(range(0, 30))
+        mvfr = cm.get_cmap('Blues', 20)(range(10, 20))
+        vfr1 = cm.get_cmap('YlGn_r', 60)(range(0, 50))
+        vfr2 = cm.get_cmap('Reds', 15)(np.full(51, 1))
 
-        return np.concatenate((grays, ncar))
+        return np.concatenate((lifr, ifr, mvfr, vfr1, vfr2))
 
     @property
     @lru_cache()

--- a/image_lists/hrrr_subset.yml
+++ b/image_lists/hrrr_subset.yml
@@ -100,6 +100,8 @@ hourly:
       - sfc
     ptmp:
       - 2m
+    ptyp:
+      - sfc
     pwtr:
       - sfc
     ref:


### PR DESCRIPTION
small changes to create a new color table for visibility, that emulates the one used by NOAA MDL.

Will confirm with Terra that this is the correct table to simulate.

passed pylint an pytest.

Comparison plots below (current GSL, MDL, an new GSL)

<img width="599" alt="Screen Shot 2021-08-03 at 9 08 15 AM" src="https://user-images.githubusercontent.com/56739562/128074212-49898c98-04fd-4433-8750-a8b968dfe7f4.png">
<img width="753" alt="Screen Shot 2021-08-02 at 8 59 23 PM" src="https://user-images.githubusercontent.com/56739562/128074223-31b9d7b6-8c9d-4dfa-accc-01393bd9ede6.png">
<img width="723" alt="Screen Shot 2021-08-03 at 8 17 17 AM" src="https://user-images.githubusercontent.com/56739562/128074234-f5cfe58b-f914-4f94-a3ce-f8ae38da7f76.png">

