### PR TITLE
Adding native level smoke plots

### DIFF
--- a/adb_graphics/default_specs.yml
+++ b/adb_graphics/default_specs.yml
@@ -1301,7 +1301,7 @@ trc1:
     title: Vertically Integrated Smoke
     transform: conversions.to_micro
     unit: $mg/m^2$
-  lvl4: &tracer1
+  1000ft: &tracer1
     clevs: [1, 2, 4, 6, 8, 12, 16, 20, 25, 30, 40, 60, 100, 200]
     colors: smoke_colors
     ncl_name: MASSDEN_P0_L105_{grid}
@@ -1309,9 +1309,11 @@ trc1:
     title: 1000ft AGL Smoke
     wind: True
     unit: $\mu g/m^3$
-  lvl11:
+    vertical_index: 4
+  6000ft:
     <<: *tracer1
     title: 6000ft AGL Smoke
+    vertical_index: 11
   sfc:
     clevs: [1, 2, 4, 6, 8, 12, 16, 20, 25, 30, 40, 60, 100, 200]
     colors: smoke_colors
@@ -1334,12 +1336,14 @@ u:
   700mb: *ua_uwind
   850mb: *ua_uwind
   925mb: *ua_uwind
-  lvl4:
+  1000ft:
     ncl_name: UGRD_P0_L105_{grid}
     transform: conversions.ms_to_kt
-  lvl11:
+    vertical_index: 4
+  6000ft:
     ncl_name: UGRD_P0_L105_{grid}
     transform: conversions.ms_to_kt
+    vertical_index: 11
   max:
     ncl_name: MAXUW_P8_L103_{grid}_max1h
     transform: conversions.ms_to_kt
@@ -1389,12 +1393,14 @@ v:
   700mb: *ua_vwind
   850mb: *ua_vwind
   925mb: *ua_vwind
-  lvl4:
+  1000ft:
     ncl_name: VGRD_P0_L105_{grid}
     transform: conversions.ms_to_kt
-  lvl11:
+    vertical_index: 4
+  6000ft:
     ncl_name: VGRD_P0_L105_{grid}
     transform: conversions.ms_to_kt
+    vertical_index: 11
   max:
     ncl_name: MAXVW_P8_L103_{grid}_max1h
     transform: conversions.ms_to_kt

--- a/adb_graphics/default_specs.yml
+++ b/adb_graphics/default_specs.yml
@@ -1301,24 +1301,17 @@ trc1:
     title: Vertically Integrated Smoke
     transform: conversions.to_micro
     unit: $mg/m^2$
-  lvl5:
+  lvl4: &tracer1
     clevs: [1, 2, 4, 6, 8, 12, 16, 20, 25, 30, 40, 60, 100, 200]
     colors: smoke_colors
     ncl_name: MASSDEN_P0_L105_{grid}
     ticks: 0
     title: 1000ft AGL Smoke
-    vertical_index: 4
     wind: True
     unit: $\mu g/m^3$
-  lvl12:
-    clevs: [1, 2, 4, 6, 8, 12, 16, 20, 25, 30, 40, 60, 100, 200]
-    colors: smoke_colors
-    ncl_name: MASSDEN_P0_L105_{grid}
-    ticks: 0
+  lvl11:
+    <<: *tracer1
     title: 6000ft AGL Smoke
-    vertical_index: 11
-    wind: True
-    unit: $\mu g/m^3$
   sfc:
     clevs: [1, 2, 4, 6, 8, 12, 16, 20, 25, 30, 40, 60, 100, 200]
     colors: smoke_colors
@@ -1341,14 +1334,14 @@ u:
   700mb: *ua_uwind
   850mb: *ua_uwind
   925mb: *ua_uwind
+  lvl4:
+    ncl_name: UGRD_P0_L105_{grid}
+    transform: conversions.ms_to_kt
+  lvl11:
+    ncl_name: UGRD_P0_L105_{grid}
+    transform: conversions.ms_to_kt
   max:
     ncl_name: MAXUW_P8_L103_{grid}_max1h
-    transform: conversions.ms_to_kt
-  lvl5:
-    ncl_name: UGRD_P0_L105_{grid}
-    transform: conversions.ms_to_kt
-  lvl12:
-    ncl_name: UGRD_P0_L105_{grid}
     transform: conversions.ms_to_kt
   ua:
     <<: *ua_uwind
@@ -1396,10 +1389,10 @@ v:
   700mb: *ua_vwind
   850mb: *ua_vwind
   925mb: *ua_vwind
-  lvl5:
+  lvl4:
     ncl_name: VGRD_P0_L105_{grid}
     transform: conversions.ms_to_kt
-  lvl12:
+  lvl11:
     ncl_name: VGRD_P0_L105_{grid}
     transform: conversions.ms_to_kt
   max:

--- a/adb_graphics/default_specs.yml
+++ b/adb_graphics/default_specs.yml
@@ -1336,13 +1336,12 @@ u:
   700mb: *ua_uwind
   850mb: *ua_uwind
   925mb: *ua_uwind
-  1000ft:
+  1000ft: &nat_uwind
     ncl_name: UGRD_P0_L105_{grid}
     transform: conversions.ms_to_kt
     vertical_index: 4
   6000ft:
-    ncl_name: UGRD_P0_L105_{grid}
-    transform: conversions.ms_to_kt
+    <<: *nat_uwind
     vertical_index: 11
   max:
     ncl_name: MAXUW_P8_L103_{grid}_max1h
@@ -1393,13 +1392,12 @@ v:
   700mb: *ua_vwind
   850mb: *ua_vwind
   925mb: *ua_vwind
-  1000ft:
+  1000ft: &nat_vwind
     ncl_name: VGRD_P0_L105_{grid}
     transform: conversions.ms_to_kt
     vertical_index: 4
   6000ft:
-    ncl_name: VGRD_P0_L105_{grid}
-    transform: conversions.ms_to_kt
+    <<: *nat_vwind
     vertical_index: 11
   max:
     ncl_name: MAXVW_P8_L103_{grid}_max1h

--- a/adb_graphics/default_specs.yml
+++ b/adb_graphics/default_specs.yml
@@ -1301,6 +1301,24 @@ trc1:
     title: Vertically Integrated Smoke
     transform: conversions.to_micro
     unit: $mg/m^2$
+  lvl5:
+    clevs: [1, 2, 4, 6, 8, 12, 16, 20, 25, 30, 40, 60, 100, 200]
+    colors: smoke_colors
+    ncl_name: MASSDEN_P0_L105_{grid}
+    ticks: 0
+    title: 1000ft AGL Smoke
+    vertical_index: 4
+    wind: True
+    unit: $\mu g/m^3$
+  lvl12:
+    clevs: [1, 2, 4, 6, 8, 12, 16, 20, 25, 30, 40, 60, 100, 200]
+    colors: smoke_colors
+    ncl_name: MASSDEN_P0_L105_{grid}
+    ticks: 0
+    title: 6000ft AGL Smoke
+    vertical_index: 11
+    wind: True
+    unit: $\mu g/m^3$
   sfc:
     clevs: [1, 2, 4, 6, 8, 12, 16, 20, 25, 30, 40, 60, 100, 200]
     colors: smoke_colors
@@ -1325,6 +1343,12 @@ u:
   925mb: *ua_uwind
   max:
     ncl_name: MAXUW_P8_L103_{grid}_max1h
+    transform: conversions.ms_to_kt
+  lvl5:
+    ncl_name: UGRD_P0_L105_{grid}
+    transform: conversions.ms_to_kt
+  lvl12:
+    ncl_name: UGRD_P0_L105_{grid}
     transform: conversions.ms_to_kt
   ua:
     <<: *ua_uwind
@@ -1372,6 +1396,12 @@ v:
   700mb: *ua_vwind
   850mb: *ua_vwind
   925mb: *ua_vwind
+  lvl5:
+    ncl_name: VGRD_P0_L105_{grid}
+    transform: conversions.ms_to_kt
+  lvl12:
+    ncl_name: VGRD_P0_L105_{grid}
+    transform: conversions.ms_to_kt
   max:
     ncl_name: MAXVW_P8_L103_{grid}_max1h
     transform: conversions.ms_to_kt

--- a/image_lists/hrrr_nat_subset.yml
+++ b/image_lists/hrrr_nat_subset.yml
@@ -1,0 +1,6 @@
+hourly:
+  model: hrrr
+  variables:
+    trc1:
+      - 1000ft
+      - 6000ft

--- a/image_lists/rrfs_subset.yml
+++ b/image_lists/rrfs_subset.yml
@@ -92,6 +92,8 @@ hourly:
       - sfc
     ptmp:
       - 2m
+    ptyp
+      - sfc
     pwtr:
       - sfc
     ref:

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -357,8 +357,6 @@ class TestDefaultSpecs():
             'bndylay', # boundary layer cld cover
             'esbl',    # ???
             'esblmn',  # ???
-            # '1000ft',  # 1000 feet above ground level
-            # '6000ft',  # 6000 feet above ground level
             'high',    # high clouds
             'int',     # vertical integral
             'low',     # low clouds

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -357,6 +357,8 @@ class TestDefaultSpecs():
             'bndylay', # boundary layer cld cover
             'esbl',    # ???
             'esblmn',  # ???
+            # '1000ft',  # 1000 feet above ground level
+            # '6000ft',  # 6000 feet above ground level
             'high',    # high clouds
             'int',     # vertical integral
             'low',     # low clouds
@@ -382,6 +384,7 @@ class TestDefaultSpecs():
         allowed_lev_type = [
             'cm',      # centimeters
             'ds',      # difference
+            'ft',      # feet
             'km',      # kilometers
             'm',       # meters
             'mm',      # millimeters


### PR DESCRIPTION
Added changes to default_specs.yml to plot 1000ft AGL and 6000ft AGL smoke with winds.

![image](https://user-images.githubusercontent.com/58485074/128733716-5804534b-a2af-4dca-9730-e3f7cbd52016.png)
![image](https://user-images.githubusercontent.com/58485074/128734824-8c8df3ee-df45-4811-991c-945bd9b8f7ae.png)
![image](https://user-images.githubusercontent.com/58485074/128734948-d01c62f2-478a-46b6-93a3-bbe818124b0b.png)
![image](https://user-images.githubusercontent.com/58485074/128735199-0e897887-8409-4010-88a0-e35b2a8c4356.png)
