### PR TITLE
Fix for RRFS and RTMA_dev1 (RRFS-based) skewT plots (hydrometeors and longitudes)

### DIFF
--- a/adb_graphics/datahandler/gribdata.py
+++ b/adb_graphics/datahandler/gribdata.py
@@ -259,6 +259,8 @@ class UPPData(specs.VarSpec):
         '''
 
         lats, lons = self.latlons()
+        adjust = 360 if np.any(lons < 0) else 0
+        lons = lons + adjust
         max_x, max_y = np.shape(lats)
 
         # Numpy magic to grab the X, Y grid point nearest the profile site
@@ -852,11 +854,12 @@ class profileData(UPPData):
         # The variable lenght site name is included past column 37
         self.site_name = loc[37:].rstrip()
 
-        # Convert the string to a number. Longitude should be negative for all
+        # Convert the string to a number. Longitude should be positive for all
         # these sites.
         self.site_lat = float(lat)
-#        self.site_lon = -float(lon)
-        self.site_lon = 360.0 - float(lon)
+        self.site_lon = -float(lon) # lons are -180 but without minus sign in input file
+        if self.site_lon < 0:
+            self.site_lon = self.site_lon + 360.0
 
     def values(self, level=None, name=None, **kwargs):
 

--- a/adb_graphics/datahandler/gribdata.py
+++ b/adb_graphics/datahandler/gribdata.py
@@ -856,10 +856,10 @@ class profileData(UPPData):
 
         # Convert the string to a number. Longitude should be positive for all
         # these sites.
-	# The conus_raobs file uses -180 to 180, but leaves off the minus sign,
-	# i.e., the values are in degrees West. So, first we need to add the
-	# minus sign to convert the longitude to deg East, and then need to
-	# adjust to the 0 to 360 system.
+        # The conus_raobs file uses -180 to 180, but leaves off the minus sign,
+        # i.e., the values are in degrees West. So, first we need to add the
+        # minus sign to convert the longitude to deg East, and then need to
+        # adjust to the 0 to 360 system.
         self.site_lat = float(lat)
         self.site_lon = -float(lon) # lons are -180 but without minus sign in input file
         if self.site_lon < 0:

--- a/adb_graphics/datahandler/gribdata.py
+++ b/adb_graphics/datahandler/gribdata.py
@@ -855,7 +855,8 @@ class profileData(UPPData):
         # Convert the string to a number. Longitude should be negative for all
         # these sites.
         self.site_lat = float(lat)
-        self.site_lon = -float(lon)
+#        self.site_lon = -float(lon)
+        self.site_lon = 360.0 - float(lon)
 
     def values(self, level=None, name=None, **kwargs):
 

--- a/adb_graphics/datahandler/gribdata.py
+++ b/adb_graphics/datahandler/gribdata.py
@@ -856,6 +856,10 @@ class profileData(UPPData):
 
         # Convert the string to a number. Longitude should be positive for all
         # these sites.
+	# The conus_raobs file uses -180 to 180, but leaves off the minus sign,
+	# i.e., the values are in degrees West. So, first we need to add the
+	# minus sign to convert the longitude to deg East, and then need to
+	# adjust to the 0 to 360 system.
         self.site_lat = float(lat)
         self.site_lon = -float(lon) # lons are -180 but without minus sign in input file
         if self.site_lon < 0:

--- a/adb_graphics/figures/skewt.py
+++ b/adb_graphics/figures/skewt.py
@@ -110,7 +110,11 @@ class SkewTDiagram(gribdata.profileData):
         for mixr, settings in mixing_ratios.items():
             # Get the profile values
             scale = settings.get('scale')
-            profile = np.asarray(self.values(name=mixr)) * 1000. * scale
+            try:
+                profile = np.asarray(self.values(name=mixr)) * 1000. * scale
+            except errors.GribReadError:
+                print(f'missing {mixr} for hydrometeor plot, skipping that field.')
+                continue
             mixr_total = 0.
             for n in range(nlevs):
                 if n == 0:


### PR DESCRIPTION
This set of changes is to correct problems with  RRFS and  RRFS-based RTMA_dev1 skewT  plotting.  Two issues are corrected
- longitudes were not consistent for -180 to +180 versus 0 to 360.  Checks were added to adjust either way.
- The skewT  code crashed if any of the  hydrometeor fields were not in the grib file,  and cloud water is not currently in the files.  The code was set to skip over missing fields and continue.

passed pylint, pytest needs to be checked (my own local pytest has a big).

sample plots:
![image1](https://user-images.githubusercontent.com/56739562/131734615-c6891529-f3f1-4e09-91a5-1bcf2604f765.png)
![image2](https://user-images.githubusercontent.com/56739562/131734634-00b5d60c-7f4b-4a15-b02a-2157def58c8f.png)
![999_74001_skewt_f000](https://user-images.githubusercontent.com/56739562/131734642-85fd702b-94d8-4e27-8dfd-74e2f64ab15c.png)
