### PR TITLE
Changes needed for RRFS NA 3km

### DIFF
--- a/adb_graphics/datahandler/gribfile.py
+++ b/adb_graphics/datahandler/gribfile.py
@@ -68,8 +68,7 @@ class GribFiles():
 
         self.contents = self._load(filenames)
 
-    @staticmethod
-    def free_fcst_names(ds, fcst_type):
+    def free_fcst_names(self, ds, fcst_type):
 
         ''' Given an opened dataset, return a dict of original variable names
         (key) and the desired name (value) '''
@@ -87,11 +86,14 @@ class GribFiles():
                 # Don't rename these variables at early hours
                 odd_variables = [
                     'ASNOW',
-                    'CDLYR',
                     'FRZR',
                     'LRGHR',
-                    'TCDC',
                     ]
+                if self.model != 'rrfs':
+                    odd_variables.extend([
+                        'CDLYR',
+                        'TCDC',
+                        ])
                 needs_renaming = var.split('_')[0] not in odd_variables
                 if suffix in special_suffixes and needs_renaming:
                     new_suffix = f'{suffix}1h'
@@ -106,9 +108,25 @@ class GribFiles():
                     'TCDC',
                     'WEASD',
                     ]
-                needs_renaming = var.split('_')[0] in odd_variables
-                contains_suffix = [suf for suf in special_suffixes if suf in
-                                   suffix and suffix != f'{suf}1h']
+                variable = var.split('_')[0]
+                needs_renaming = variable in odd_variables
+                contains_suffix = []
+                for suf in special_suffixes:
+
+                    # The LRGHR variable behaves differently in RRFS than in all
+                    # others! At 7 hours, it starts averaging since 6h. From 0-6
+                    # h it's named with suffix avg, after its named avg1h,
+                    # avg2h, etc.
+                    if self.model == 'rrfs' and \
+                        variable == 'LRGHR' and \
+                        suffix == f'{suf}1h':
+                        contains_suffix.append(suf)
+
+                    # All the variables that need to be renamed. In most cases,
+                    # exclude the "1h" accumulated variables
+                    if suf in suffix and suffix != f'{suf}1h':
+                        contains_suffix.append(suf)
+
                 if contains_suffix and needs_renaming:
                     ret[var] = var.replace(suffix, contains_suffix[0])
 

--- a/create_graphics.py
+++ b/create_graphics.py
@@ -229,6 +229,12 @@ def parse_args():
 
     # Short args
     parser.add_argument(
+        '-a',
+        dest='data_age',
+        default=3,
+        help='Age in minutes required for data files to be complete. Default = 3',
+        )
+    parser.add_argument(
         '-d',
         dest='data_root',
         help='Cycle-independant data directory location.',
@@ -273,6 +279,12 @@ def parse_args():
         help='Start time in YYYYMMDDHH format',
         required=True,
         type=utils.to_datetime,
+        )
+    parser.add_argument(
+        '-w',
+        dest='wait_time',
+        default=10,
+        help='Time in minutes to wait on data files to be available. Default = 10',
         )
     parser.add_argument(
         '-z',
@@ -547,8 +559,9 @@ def graphics_driver(cla):
             grib_path = os.path.join(cla.data_root,
                                      cla.file_tmpl.format(FCST_TIME=fhr))
 
-            # UPP is most likely done writing if it hasn't written in 3 mins
-            if os.path.exists(grib_path) and utils.old_enough(3, grib_path):
+            # UPP is most likely done writing if it hasn't written in data_age
+            # mins (default is 3 to address most CONUS-sized domains)
+            if os.path.exists(grib_path) and utils.old_enough(cla.data_age, grib_path):
                 fcst_hours.remove(fhr)
             else:
                 # Try next forecast hour
@@ -590,9 +603,10 @@ def graphics_driver(cla):
             # Keep track of last time we did something useful
             timer_end = time.time()
 
-        # Give up trying to process remaining forecast hours after waiting 10
-        # arbitrary mins since doing something useful.
-        if time.time() - timer_end > 600:
+        # Give up trying to process remaining forecast hours after waiting
+        # wait_time mins. This accounts for slower UPP processes. Default for
+        # most CONUS-sized domains is 10 mins.
+        if time.time() - timer_end > cla.wait_time * 60:
             print(f"Exiting with forecast hours remaining: {fcst_hours}")
             print((('-' * 80)+'\n') * 2)
             break


### PR DESCRIPTION
Allows the wait time and file age to be specified via command line arguments. Default is set to the times used for HRRR/CONUS domains, while the RRFS NA will need to wait 15 minutes between UPP runs and files should be 5 minutes old (settings for hot fix applied to the real-time run).

Also fixes issues with the naming of variables for RRFS when accumulating over time, especially a fix that allows forecasts to accumulate beyond 6 hours (grib variable LRGHR).
