### PR TITLE
Memory leak fixes

### DIFF
--- a/adb_graphics/conversions.py
+++ b/adb_graphics/conversions.py
@@ -11,19 +11,19 @@ def k_to_c(field: np.ndarray, **kwargs) -> np.ndarray:
 
     ''' Conversion from Kelvin to Celsius '''
 
-    return np.asarray(field) - 273.15
+    return field - 273.15
 
 def k_to_f(field: np.ndarray, **kwargs) -> np.ndarray:
 
     ''' Conversion from Kelvin to Farenheit '''
 
-    return (np.asarray(field) - 273.15) * 9/5 + 32
+    return (field - 273.15) * 9/5 + 32
 
 def kgm2_to_in(field: np.ndarray, **kwargs) -> np.ndarray:
 
     ''' Conversion from kg per m^2 to inches '''
 
-    return np.asarray(field) * 0.03937
+    return field * 0.03937
 
 def magnitude(a: np.ndarray, b: np.ndarray, **kwargs) -> np.ndarray:
 
@@ -35,63 +35,63 @@ def m_to_dm(field: np.ndarray, **kwargs) -> np.ndarray:
 
     ''' Conversion from meters to decameters '''
 
-    return np.asarray(field) / 10.
+    return field / 10.
 
 def m_to_in(field: np.ndarray, **kwargs) -> np.ndarray:
 
     ''' Conversion from meters to inches '''
 
-    return np.asarray(field) * 39.3701
+    return field * 39.3701
 
 def m_to_kft(field: np.ndarray, **kwargs) -> np.ndarray:
 
     ''' Conversion from meters to kilofeet '''
 
-    return np.asarray(field) / 304.8
+    return field / 304.8
 
 def m_to_mi(field: np.ndarray, **kwargs) -> np.ndarray:
 
     ''' Conversion from meters to miles '''
-    return np.asarray(field) / 1609.344
+    return field / 1609.344
 
 def ms_to_kt(field: np.ndarray, **kwargs) -> np.ndarray:
 
     ''' Conversion from m s-1 to knots '''
 
-    return np.asarray(field) * 1.9438
+    return field * 1.9438
 
 def pa_to_hpa(field: np.ndarray, **kwargs) -> np.ndarray:
 
     ''' Conversion from Pascals to hectopascals '''
 
-    return np.asarray(field) / 100.
+    return field / 100.
 
 def percent(field: np.ndarray, **kwargs) -> np.ndarray:
 
     ''' Conversion from values between 0 - 1 to percent '''
 
-    return np.asarray(field) * 100.
+    return field * 100.
 
 def to_micro(field: np.ndarray, **kwargs) -> np.ndarray:
 
     ''' Convert field to micro '''
 
-    return np.asarray(field) * 1E6
+    return field * 1E6
 
 def vvel_scale(field: np.ndarray, **kwargs) -> np.ndarray:
 
     ''' Scale vertical velocity for plotting  '''
 
-    return np.asarray(field) * -10
+    return field * -10
 
 def vort_scale(field: np.ndarray, **kwargs) -> np.ndarray:
 
     ''' Scale vorticity for plotting  '''
 
-    return np.asarray(field) / 1E-05
+    return field / 1E-05
 
 def weasd_to_1hsnw(field: np.ndarray, **kwargs) -> np.ndarray:
 
     ''' Conversion from snow wter equiv to snow (10:1 ratio) '''
 
-    return np.asarray(field) * 10.
+    return field * 10.

--- a/adb_graphics/conversions.py
+++ b/adb_graphics/conversions.py
@@ -7,90 +7,90 @@ converted values as output.
 
 import numpy as np
 
-def k_to_c(field: np.ndarray, **kwargs) -> np.ndarray:
+def k_to_c(field, **kwargs):
 
     ''' Conversion from Kelvin to Celsius '''
 
     return field - 273.15
 
-def k_to_f(field: np.ndarray, **kwargs) -> np.ndarray:
+def k_to_f(field, **kwargs):
 
     ''' Conversion from Kelvin to Farenheit '''
 
     return (field - 273.15) * 9/5 + 32
 
-def kgm2_to_in(field: np.ndarray, **kwargs) -> np.ndarray:
+def kgm2_to_in(field, **kwargs):
 
     ''' Conversion from kg per m^2 to inches '''
 
     return field * 0.03937
 
-def magnitude(a: np.ndarray, b: np.ndarray, **kwargs) -> np.ndarray:
+def magnitude(a, b, **kwargs):
 
     ''' Return the magnitude of vector components '''
 
     return np.sqrt(np.square(a) + np.square(b))
 
-def m_to_dm(field: np.ndarray, **kwargs) -> np.ndarray:
+def m_to_dm(field, **kwargs):
 
     ''' Conversion from meters to decameters '''
 
     return field / 10.
 
-def m_to_in(field: np.ndarray, **kwargs) -> np.ndarray:
+def m_to_in(field, **kwargs):
 
     ''' Conversion from meters to inches '''
 
     return field * 39.3701
 
-def m_to_kft(field: np.ndarray, **kwargs) -> np.ndarray:
+def m_to_kft(field, **kwargs):
 
     ''' Conversion from meters to kilofeet '''
 
     return field / 304.8
 
-def m_to_mi(field: np.ndarray, **kwargs) -> np.ndarray:
+def m_to_mi(field, **kwargs):
 
     ''' Conversion from meters to miles '''
     return field / 1609.344
 
-def ms_to_kt(field: np.ndarray, **kwargs) -> np.ndarray:
+def ms_to_kt(field, **kwargs):
 
     ''' Conversion from m s-1 to knots '''
 
     return field * 1.9438
 
-def pa_to_hpa(field: np.ndarray, **kwargs) -> np.ndarray:
+def pa_to_hpa(field, **kwargs):
 
     ''' Conversion from Pascals to hectopascals '''
 
     return field / 100.
 
-def percent(field: np.ndarray, **kwargs) -> np.ndarray:
+def percent(field, **kwargs):
 
     ''' Conversion from values between 0 - 1 to percent '''
 
     return field * 100.
 
-def to_micro(field: np.ndarray, **kwargs) -> np.ndarray:
+def to_micro(field, **kwargs):
 
     ''' Convert field to micro '''
 
     return field * 1E6
 
-def vvel_scale(field: np.ndarray, **kwargs) -> np.ndarray:
+def vvel_scale(field, **kwargs):
 
     ''' Scale vertical velocity for plotting  '''
 
     return field * -10
 
-def vort_scale(field: np.ndarray, **kwargs) -> np.ndarray:
+def vort_scale(field, **kwargs):
 
     ''' Scale vorticity for plotting  '''
 
     return field / 1E-05
 
-def weasd_to_1hsnw(field: np.ndarray, **kwargs) -> np.ndarray:
+def weasd_to_1hsnw(field, **kwargs):
 
     ''' Conversion from snow wter equiv to snow (10:1 ratio) '''
 

--- a/adb_graphics/datahandler/gribdata.py
+++ b/adb_graphics/datahandler/gribdata.py
@@ -100,7 +100,7 @@ class UPPData(specs.VarSpec):
 
         return self._get_field(self.ncl_name(self.vspec))
 
-    def field_diff(self, values, variable2, level2, **kwargs) -> np.ndarray:
+    def field_diff(self, values, variable2, level2, **kwargs):
 
         # pylint: disable=unused-argument
 
@@ -112,7 +112,7 @@ class UPPData(specs.VarSpec):
 
         return diff
 
-    def field_mean(self, values, variable, levels, **kwargs) -> np.ndarray:
+    def field_mean(self, values, variable, levels, **kwargs):
 
         # pylint: disable=unused-argument
 
@@ -394,7 +394,7 @@ class UPPData(specs.VarSpec):
         return lev_val, lev_unit
 
     @staticmethod
-    def opposite(values, **kwargs) -> np.ndarray:
+    def opposite(values, **kwargs):
     # pylint: disable=unused-argument
 
         ''' Returns the opposite of input values  '''
@@ -462,7 +462,7 @@ class fieldData(UPPData):
         self.level = level
         self.contour_kwargs = kwargs.get('contour_kwargs', {})
 
-    def aviation_flight_rules(self, values, **kwargs) -> np.ndarray:
+    def aviation_flight_rules(self, values, **kwargs):
         # pylint: disable=unused-argument
 
         '''
@@ -524,7 +524,7 @@ class fieldData(UPPData):
         lat, lon = self.latlons()
         return [lat[0, 0], lat[-1, -1], lon[0, 0], lon[-1, -1]]
 
-    def fire_weather_index(self, values, **kwargs) -> np.ndarray:
+    def fire_weather_index(self, values, **kwargs):
 
         # pylint: disable=unused-argument
 
@@ -634,7 +634,7 @@ class fieldData(UPPData):
 
         return grid_info
 
-    def run_total(self, values, **kwargs) -> np.ndarray:
+    def run_total(self, values, **kwargs):
 
         ''' Sums over all the forecast lead times available. '''
 
@@ -642,7 +642,7 @@ class fieldData(UPPData):
 
         return values.sum(dim='fcst_hr')
 
-    def supercooled_liquid_water(self, values, **kwargs) -> np.ndarray:
+    def supercooled_liquid_water(self, values, **kwargs):
 
         # pylint: disable=unused-argument
 
@@ -706,7 +706,7 @@ class fieldData(UPPData):
 
         return self.vspec.get('unit', self.field.units)
 
-    def values(self, level=None, name=None, **kwargs) -> np.ndarray:
+    def values(self, level=None, name=None, **kwargs):
 
         '''
         Returns the numpy array of values at the requested level for the

--- a/adb_graphics/datahandler/gribdata.py
+++ b/adb_graphics/datahandler/gribdata.py
@@ -11,6 +11,7 @@ from string import digits, ascii_letters
 
 from matplotlib import cm
 import numpy as np
+import xarray as xr
 
 from .. import conversions
 from .. import errors
@@ -480,7 +481,7 @@ class fieldData(UPPData):
 
         vis.close()
 
-        return flru
+        return xr.DataArray(flru)
 
     @property
     def cmap(self):

--- a/adb_graphics/datahandler/gribfile.py
+++ b/adb_graphics/datahandler/gribfile.py
@@ -141,6 +141,7 @@ class GribFiles():
         for files in filenames.values():
             if files:
                 gfile = xr.open_dataset(files[0],
+                                        cache=False,
                                         engine='pynio',
                                         lock=False,
                                         backend_kwargs=dict(format="grib2"),
@@ -216,7 +217,6 @@ class GribFiles():
         return ret
 
     @property
-    @lru_cache()
     def open_kwargs(self):
 
         ''' Defines the key word arguments used by the various calls to XArray
@@ -224,6 +224,7 @@ class GribFiles():
 
         return dict(
             backend_kwargs=dict(format="grib2"),
+            cache=False,
             combine='nested',
             compat='override',
             concat_dim=list(self.coord_dims.keys())[0],

--- a/adb_graphics/datahandler/gribfile.py
+++ b/adb_graphics/datahandler/gribfile.py
@@ -4,8 +4,6 @@
 Classes that load grib files.
 '''
 
-from functools import lru_cache
-
 import xarray as xr
 
 class GribFile():

--- a/adb_graphics/figures/maps.py
+++ b/adb_graphics/figures/maps.py
@@ -142,6 +142,9 @@ class Map():
                     markersize=4,
                     )
 
+        del x
+        del y
+
     def _get_basemap(self, **get_basemap_kwargs):
 
         ''' Wrapper around basemap creation '''
@@ -357,6 +360,7 @@ class DataMap():
                         if (not isnan(data_value)) and (data_value != 0.):
                             ax.annotate(f"{data_value:.{annotate_decimal}f}", \
                                         xy=(x[i], y[i]), fontsize=10)
+                        data_value.close()
 
         # Finish with the title
         self._title()
@@ -367,6 +371,8 @@ class DataMap():
             plt.show()
 
         self.add_logo(ax)
+
+        return cf
 
     def _draw_field(self, ax, field, func, **kwargs):
 
@@ -387,11 +393,20 @@ class DataMap():
         '''
 
         x, y = self._xy_mesh(field)
-
-        return func(x, y, field.values()[::],
+        vals = field.values()[::]
+        ret = func(x, y, vals,
                     ax=ax,
                     **kwargs,
                     )
+
+        del x
+        del y
+        try:
+            vals.close()
+        except AttributeError:
+            del vals
+            print(f'CLOSE ERROR: {field.short_name} {field.level}')
+        return ret
 
     def _title(self):
 
@@ -492,7 +507,6 @@ class DataMap():
                          sizes={'spacing': 0.25},
                          )
 
-    @lru_cache()
     def _xy_mesh(self, field):
 
         ''' Helper function to create mesh for various plot. '''

--- a/adb_graphics/figures/maps.py
+++ b/adb_graphics/figures/maps.py
@@ -8,8 +8,6 @@ UPPData object) and creates a standard plot with shaded fields, contours, wind
 barbs, and descriptive annotation.
 '''
 
-from functools import lru_cache
-
 from math import isnan
 import matplotlib.pyplot as plt
 import matplotlib.image as mpimg
@@ -284,60 +282,11 @@ class DataMap():
 
         # Contour secondary fields, if requested
         if self.contour_fields:
-            for contour_field in self.contour_fields:
-                levels = contour_field.contour_kwargs.pop('levels',
-                                                          contour_field.clevs)
-
-                cc = self._draw_field(ax=ax,
-                                      field=contour_field,
-                                      func=self.map.m.contour,
-                                      levels=levels,
-                                      **contour_field.contour_kwargs,
-                                      )
-                if contour_field.short_name not in not_labeled:
-                    try:
-                        clab = plt.clabel(cc, levels[::4],
-                                          colors='w',
-                                          fmt='%1.0f',
-                                          fontsize=10,
-                                          inline=1,
-                                          )
-                        # Set the background color for the line labels to black
-                        _ = [txt.set_bbox(dict(color='k')) for txt in clab]
-
-                    except ValueError:
-                        print(f'Cannot add contour labels to map for {self.field.short_name} \
-                                {self.field.level}')
+            self._draw_contours(ax, not_labeled)
 
         # Add hatched fields, if requested
-        # Levels should be included in the settings dict here since they don't
-        # correspond to a full field of contours.
         if self.hatch_fields:
-            handles = []
-            for field in self.hatch_fields:
-                colors = field.contour_kwargs.get('colors', 'k')
-                hatches = field.contour_kwargs.get('hatches', '----')
-                labels = field.contour_kwargs.get('labels', 'XXXX')
-                linewidths = field.contour_kwargs.get('linewidths', 0.1)
-                handles.append(mpatches.Patch(edgecolor=colors[-1], facecolor='lightgrey', \
-                               label=labels, hatch=hatches[-1]))
-
-                cf = self._draw_field(ax=ax,
-                                      extend='both',
-                                      field=field,
-                                      func=self.map.m.contourf,
-                                      **field.contour_kwargs,
-                                      )
-
-                # For each level, we set the color of its hatch
-                for collection in cf.collections:
-                    collection.set_edgecolor(colors)
-                    collection.set_facecolor(['None'])
-                    collection.set_linewidth(linewidths)
-
-            # Create legend for precip type field
-            if self.field.short_name == 'ptyp':
-                plt.legend(handles=handles, loc=[0.25, 0.03])
+            self._draw_hatches(ax)
 
         # Add wind barbs, if requested
         add_wind = self.field.vspec.get('wind', False)
@@ -347,20 +296,7 @@ class DataMap():
         # Add field values at airports
         annotate = self.field.vspec.get('annotate', False)
         if annotate:
-            annotate_decimal = self.field.vspec.get('annotate_decimal', 0)
-            lats = self.map.airports[:, 0]
-            lons = self.map.airports[:, 1]
-            x, y = self.map.m(lons, lats)
-            for i, lat in enumerate(lats):
-                if self.map.corners[1] > lat > self.map.corners[0] and \
-                   self.map.corners[3] > lons[i] > self.map.corners[2]:
-                    xgrid, ygrid = self.field.get_xypoint(lat, lons[i])
-                    if xgrid > 0 and ygrid > 0:
-                        data_value = self.field.values()[xgrid, ygrid]
-                        if (not isnan(data_value)) and (data_value != 0.):
-                            ax.annotate(f"{data_value:.{annotate_decimal}f}", \
-                                        xy=(x[i], y[i]), fontsize=10)
-                        data_value.close()
+            self._draw_field_values(ax)
 
         # Finish with the title
         self._title()
@@ -373,6 +309,36 @@ class DataMap():
         self.add_logo(ax)
 
         return cf
+
+    def _draw_contours(self, ax, not_labeled):
+
+        ''' Draw the contour fields requested. '''
+
+        for contour_field in self.contour_fields:
+            levels = contour_field.contour_kwargs.pop('levels',
+                                                      contour_field.clevs)
+
+            cc = self._draw_field(ax=ax,
+                                  field=contour_field,
+                                  func=self.map.m.contour,
+                                  levels=levels,
+                                  **contour_field.contour_kwargs,
+                                  )
+            if contour_field.short_name not in not_labeled:
+                try:
+                    clab = plt.clabel(cc, levels[::4],
+                                      colors='w',
+                                      fmt='%1.0f',
+                                      fontsize=10,
+                                      inline=1,
+                                      )
+                    # Set the background color for the line labels to black
+                    _ = [txt.set_bbox(dict(color='k')) for txt in clab]
+
+                except ValueError:
+                    print(f'Cannot add contour labels to map for {self.field.short_name} \
+                            {self.field.level}')
+
 
     def _draw_field(self, ax, field, func, **kwargs):
 
@@ -395,9 +361,9 @@ class DataMap():
         x, y = self._xy_mesh(field)
         vals = field.values()[::]
         ret = func(x, y, vals,
-                    ax=ax,
-                    **kwargs,
-                    )
+                   ax=ax,
+                   **kwargs,
+                   )
 
         del x
         del y
@@ -407,6 +373,57 @@ class DataMap():
             del vals
             print(f'CLOSE ERROR: {field.short_name} {field.level}')
         return ret
+
+    def _draw_field_values(self, ax):
+
+        ''' Add the text value of the field at airport locations. '''
+        annotate_decimal = self.field.vspec.get('annotate_decimal', 0)
+        lats = self.map.airports[:, 0]
+        lons = 360 + self.map.airports[:, 1]
+        x, y = self.map.m(lons, lats)
+        data_values = self.field.values()
+        for i, lat in enumerate(lats):
+            if self.map.corners[1] > lat > self.map.corners[0] and \
+               self.map.corners[3] > lons[i] > self.map.corners[2]:
+                xgrid, ygrid = self.field.get_xypoint(lat, lons[i])
+                data_value = data_values[xgrid, ygrid]
+                if xgrid > 0 and ygrid > 0:
+                    if (not isnan(data_value)) and (data_value != 0.):
+                        ax.annotate(f"{data_value:.{annotate_decimal}f}", \
+                                    xy=(x[i], y[i]), fontsize=10)
+        data_values.close()
+
+    def _draw_hatches(self, ax):
+
+        ''' Draw the hatched regions requested. '''
+
+        # Levels should be included in the settings dict here since they don't
+        # correspond to a full field of contours.
+        handles = []
+        for field in self.hatch_fields:
+            colors = field.contour_kwargs.get('colors', 'k')
+            hatches = field.contour_kwargs.get('hatches', '----')
+            labels = field.contour_kwargs.get('labels', 'XXXX')
+            linewidths = field.contour_kwargs.get('linewidths', 0.1)
+            handles.append(mpatches.Patch(edgecolor=colors[-1], facecolor='lightgrey', \
+                           label=labels, hatch=hatches[-1]))
+
+            cf = self._draw_field(ax=ax,
+                                  extend='both',
+                                  field=field,
+                                  func=self.map.m.contourf,
+                                  **field.contour_kwargs,
+                                  )
+
+            # For each level, we set the color of its hatch
+            for collection in cf.collections:
+                collection.set_edgecolor(colors)
+                collection.set_facecolor(['None'])
+                collection.set_linewidth(linewidths)
+
+        # Create legend for precip type field
+        if self.field.short_name == 'ptyp':
+            plt.legend(handles=handles, loc=[0.25, 0.03])
 
     def _title(self):
 

--- a/adb_graphics/specs.py
+++ b/adb_graphics/specs.py
@@ -7,7 +7,6 @@ colors from a color map.
 
 import abc
 from itertools import chain
-from functools import lru_cache
 from matplotlib import cm
 from matplotlib import colors as mpcolors
 import numpy as np
@@ -44,7 +43,6 @@ class VarSpec(abc.ABC):
         return colors
 
     @property
-    @lru_cache()
     def cin_colors(self) -> np.ndarray:
 
         ''' Default color map for Convective Inhibition '''
@@ -69,7 +67,6 @@ class VarSpec(abc.ABC):
         from a config file like default_specs.yml. '''
 
     @property
-    @lru_cache()
     def ceil_colors(self) -> np.ndarray:
 
         ''' Default color map for Ceiling '''
@@ -80,7 +77,6 @@ class VarSpec(abc.ABC):
         return np.concatenate((grays, ncar, grays))
 
     @property
-    @lru_cache()
     def cldcov_colors(self) -> np.ndarray:
 
         ''' Default color map for Cloud Cover '''
@@ -91,7 +87,6 @@ class VarSpec(abc.ABC):
         return np.concatenate((grays, ncar))
 
     @property
-    @lru_cache()
     def cref_colors(self) -> np.ndarray:
 
         ''' Default color map for Reflectivity '''
@@ -103,7 +98,6 @@ class VarSpec(abc.ABC):
         return np.concatenate((grays, nws, white))
 
     @property
-    @lru_cache()
     def dewp_colors(self) -> np.ndarray:
 
         ''' Default color map for Dew point temperature '''
@@ -113,7 +107,6 @@ class VarSpec(abc.ABC):
         return ctable
 
     @property
-    @lru_cache()
     def fire_power_colors(self) -> np.ndarray:
 
         ''' Default color map for fire power plot. '''
@@ -122,7 +115,6 @@ class VarSpec(abc.ABC):
         green_orange = cm.get_cmap('RdYlGn_r', 10)([1, 7, 8, 9])
         return np.concatenate((blues, green_orange))
 
-    @lru_cache()
     def flru_colors(self) -> np.ndarray:
 
         ''' Default color map for Ceiling '''
@@ -132,7 +124,6 @@ class VarSpec(abc.ABC):
         return ctable
 
     @property
-    @lru_cache()
     def frzn_colors(self) -> np.ndarray:
 
         ''' Default color map for Frozen Precip % '''
@@ -143,7 +134,6 @@ class VarSpec(abc.ABC):
         return np.concatenate((grays, ncar))
 
     @property
-    @lru_cache()
     def goes_colors(self) -> np.ndarray:
 
         ''' Default color map for simulated GOES IR satellite '''
@@ -154,7 +144,6 @@ class VarSpec(abc.ABC):
         return np.concatenate((grays[-1:], grays, ctable2, grays[1:]))
 
     @property
-    @lru_cache()
     def graupel_colors(self) -> np.ndarray:
 
         ''' Default color map for Max Vertically Integrated Graupel '''
@@ -165,7 +154,6 @@ class VarSpec(abc.ABC):
         return np.concatenate((grays, ncar))
 
     @property
-    @lru_cache()
     def hail_colors(self) -> np.ndarray:
 
         ''' Default color map for Hail diameter '''
@@ -176,7 +164,6 @@ class VarSpec(abc.ABC):
         return np.concatenate((grays, ncar))
 
     @property
-    @lru_cache()
     def heat_flux_colors(self) -> np.ndarray:
 
         ''' Default color map for Latent/Sensible Heat Flux '''
@@ -187,7 +174,6 @@ class VarSpec(abc.ABC):
         return np.concatenate((grays, ctable))
 
     @property
-    @lru_cache()
     def lcl_colors(self) -> np.ndarray:
 
         ''' Default color map for Lifted Condensation Level '''
@@ -197,7 +183,6 @@ class VarSpec(abc.ABC):
         return ctable
 
     @property
-    @lru_cache()
     def lifted_index_colors(self) -> np.ndarray:
 
         ''' Default color map for Lifted Index '''
@@ -209,7 +194,6 @@ class VarSpec(abc.ABC):
         return ctable
 
     @property
-    @lru_cache()
     def mdn_colors(self) -> np.ndarray:
 
         ''' Default color map for Max Downdraft '''
@@ -219,7 +203,6 @@ class VarSpec(abc.ABC):
         return np.concatenate((others, grays))
 
     @property
-    @lru_cache()
     def mean_vvel_colors(self) -> np.ndarray:
 
         ''' Default color map for Mean Vertical Velocity '''
@@ -229,7 +212,6 @@ class VarSpec(abc.ABC):
         return ctable
 
     @property
-    @lru_cache()
     def mup_colors(self) -> np.ndarray:
 
         ''' Default color map for Max Updraft '''
@@ -239,7 +221,6 @@ class VarSpec(abc.ABC):
         return np.concatenate((grays, others))
 
     @property
-    @lru_cache()
     def pbl_colors(self) -> np.ndarray:
 
         ''' Default color map for PBL Height '''
@@ -248,7 +229,6 @@ class VarSpec(abc.ABC):
                           (range(15, 60, 3))
 
     @property
-    @lru_cache()
     def pcp_colors(self) -> np.ndarray:
 
         ''' Default color map for Hourly Precipitation '''
@@ -259,7 +239,6 @@ class VarSpec(abc.ABC):
         return np.concatenate((grays, ncar))
 
     @property
-    @lru_cache()
     def ps_colors(self) -> np.ndarray:
 
         ''' Default color map for Surface Pressure '''
@@ -270,7 +249,6 @@ class VarSpec(abc.ABC):
         return np.concatenate((grays, ncar))
 
     @property
-    @lru_cache()
     def pw_colors(self) -> np.ndarray:
 
         ''' Default color map for Precipitable Water '''
@@ -283,7 +261,6 @@ class VarSpec(abc.ABC):
         return np.concatenate((grays, ncar, bupu, cool))
 
     @property
-    @lru_cache()
     def radiation_colors(self) -> np.ndarray:
 
         ''' Default color map for Longwave Radiation '''
@@ -294,7 +271,6 @@ class VarSpec(abc.ABC):
         return np.concatenate((grays, ncar))
 
     @property
-    @lru_cache()
     def radiation_bw_colors(self) -> np.ndarray:
 
         ''' Default grayscale map for Outgoing Shortwave Radiation '''
@@ -303,7 +279,6 @@ class VarSpec(abc.ABC):
                           (range(30, 110))
 
     @property
-    @lru_cache()
     def radiation_mix_colors(self) -> np.ndarray:
 
         ''' Default color map for Longwave Radiation '''
@@ -314,7 +289,6 @@ class VarSpec(abc.ABC):
         return np.concatenate((ncar, grays))
 
     @property
-    @lru_cache()
     def rainbow12_colors(self) -> np.ndarray:
 
         ''' Default color map for ACPCP, ACSNOD, HLCY, RH, and SNOD '''
@@ -325,7 +299,6 @@ class VarSpec(abc.ABC):
         return np.concatenate((grays, ncar))
 
     @property
-    @lru_cache()
     def shear_colors(self) -> np.ndarray:
 
         ''' Default color map for Vertical Shear '''
@@ -336,7 +309,6 @@ class VarSpec(abc.ABC):
         return ctable
 
     @property
-    @lru_cache()
     def smoke_colors(self) -> np.ndarray:
 
         ''' Default color map for smoke plots. '''
@@ -348,7 +320,6 @@ class VarSpec(abc.ABC):
 
 
     @property
-    @lru_cache()
     def snow_colors(self) -> np.ndarray:
 
         ''' Default color map for Snow fields '''
@@ -359,7 +330,6 @@ class VarSpec(abc.ABC):
         return np.concatenate((grays, ncar))
 
     @property
-    @lru_cache()
     def soilm_colors(self) -> np.ndarray:
 
         ''' Default color map for Soil Moisture Availability '''
@@ -368,7 +338,6 @@ class VarSpec(abc.ABC):
         return ncar
 
     @property
-    @lru_cache()
     def soilt_colors(self) -> np.ndarray:
 
         ''' Default color map for Soil Temperature '''
@@ -378,7 +347,6 @@ class VarSpec(abc.ABC):
         return ncar
 
     @property
-    @lru_cache()
     def soilw_colors(self) -> np.ndarray:
 
         ''' Default color map for Soil Moisture '''
@@ -388,7 +356,6 @@ class VarSpec(abc.ABC):
         return ncar
 
     @property
-    @lru_cache()
     def t_colors(self) -> np.ndarray:
 
         ''' Default color map for Upper-Air Temperature '''
@@ -397,7 +364,6 @@ class VarSpec(abc.ABC):
         return cm.get_cmap(self.vspec.get('cmap', 'jet'), ncolors)(range(ncolors))
 
     @property
-    @lru_cache()
     def tsfc_colors(self) -> np.ndarray:
 
         ''' Default color map for Surface Temperature '''  # WeatherBell-inspired scheme
@@ -413,7 +379,6 @@ class VarSpec(abc.ABC):
         return np.concatenate((temp1, temp2, temp3, temp4, temp5, temp6, temp7))
 
     @property
-    @lru_cache()
     def terrain_colors(self) -> np.ndarray:
 
         ''' Default color map for Terrain '''
@@ -423,7 +388,6 @@ class VarSpec(abc.ABC):
         return ctable
 
     @property
-    @lru_cache()
     def vis_colors(self) -> np.ndarray:
 
         ''' Default color map for Visibility
@@ -444,7 +408,6 @@ class VarSpec(abc.ABC):
         return np.concatenate((lifr, ifr, mvfr, vfr1, vfr2))
 
     @property
-    @lru_cache()
     def vvel_colors(self) -> np.ndarray:
 
         ''' Default color map for Vetical Velocity '''
@@ -455,7 +418,6 @@ class VarSpec(abc.ABC):
         return np.concatenate((ncar1, grays, ncar2))
 
     @property
-    @lru_cache()
     def vort_colors(self) -> np.ndarray:
 
         ''' Default color map for Absolute Vorticity '''
@@ -466,7 +428,6 @@ class VarSpec(abc.ABC):
         return np.concatenate((grays, ncar))
 
     @property
-    @lru_cache()
     def wind_colors(self) -> np.ndarray:
 
         ''' Default color map for Wind Speed '''
@@ -476,7 +437,6 @@ class VarSpec(abc.ABC):
         return np.concatenate((low, high))
 
     @property
-    @lru_cache()
     def wind_colors_high(self) -> np.ndarray:
 
         ''' Default color map for High Wind Speed '''

--- a/create_graphics.py
+++ b/create_graphics.py
@@ -456,7 +456,7 @@ def parallel_maps(cla, fhr, ds, level, model, spec, variable, workdir,
         )
 
     # Draw the map
-    f = dm.draw(show=True)
+    dm.draw(show=True)
 
     # Build the output path
     png_suffix = level if level != 'ua' else ''
@@ -481,18 +481,14 @@ def parallel_maps(cla, fhr, ds, level, model, spec, variable, workdir,
 
     fig.clear()
     # Clear the current axes.
-    plt.cla() 
+    plt.cla()
     # Clear the current figure.
-    plt.clf() 
+    plt.clf()
     # Closes all the figure windows.
-    plt.close('all')   
+    plt.close('all')
     del field
     del m
     gc.collect()
-
-    #field.values().close()
-    #for aux_field in hatch_fields + contour_fields:
-    #    aux_field.values().close()
 
 def parallel_skewt(cla, fhr, ds, site, workdir):
 

--- a/create_graphics.py
+++ b/create_graphics.py
@@ -10,6 +10,8 @@ mpl.use('Agg')
 
 import argparse
 import copy
+import gc
+
 import glob
 from multiprocessing import Pool, Process
 import os
@@ -433,13 +435,13 @@ def parallel_maps(cla, fhr, ds, level, model, spec, variable, workdir,
     else:
         inches = 10
 
-    _, ax = plt.subplots(1, 1, figsize=(inches, inches))
+    fig, ax = plt.subplots(1, 1, figsize=(inches, inches))
 
     # Generate a map object
     m = maps.Map(
         airport_fn=AIRPORTS,
         ax=ax,
-        grid_info=field.grid_info,
+        grid_info=field.grid_info(),
         model=model,
         tile=tile,
         )
@@ -454,7 +456,7 @@ def parallel_maps(cla, fhr, ds, level, model, spec, variable, workdir,
         )
 
     # Draw the map
-    dm.draw(show=True)
+    f = dm.draw(show=True)
 
     # Build the output path
     png_suffix = level if level != 'ua' else ''
@@ -476,7 +478,21 @@ def parallel_maps(cla, fhr, ds, level, model, spec, variable, workdir,
         pil_kwargs={'optimize': True},
         )
 
-    plt.close()
+
+    fig.clear()
+    # Clear the current axes.
+    plt.cla() 
+    # Clear the current figure.
+    plt.clf() 
+    # Closes all the figure windows.
+    plt.close('all')   
+    del field
+    del m
+    gc.collect()
+
+    #field.values().close()
+    #for aux_field in hatch_fields + contour_fields:
+    #    aux_field.values().close()
 
 def parallel_skewt(cla, fhr, ds, site, workdir):
 
@@ -568,6 +584,7 @@ def graphics_driver(cla):
                 fcst_hours.remove(fhr)
             else:
                 # Try next forecast hour
+                print(f'Cannot find {grib_path}')
                 continue
 
             # Create the working directory

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -33,7 +33,6 @@ def test_conversion():
     list, or int '''
 
     a = np.ones([3, 2]) * 300
-    b = list(a)
     c = a[0, 0]
 
     # Check for the right answer
@@ -69,8 +68,8 @@ def test_conversion():
 
     # Check that all functions return a np.ndarray given a collection, or single float
     for f in functions:
-        for collection in [b, c]:
-            assert isinstance(f(collection), (float, np.ndarray))
+        for collection in [a, c]:
+            assert isinstance(f(collection), type(collection))
 
 
 class MockSpecs(specs.VarSpec):

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -46,6 +46,7 @@ def test_conversion():
     assert np.array_equal(conversions.ms_to_kt(a), a * 1.9438)
     assert np.array_equal(conversions.pa_to_hpa(a), a / 100)
     assert np.array_equal(conversions.percent(a), a * 100)
+    assert np.array_equal(conversions.to_micro(a), a * 1E6)
     assert np.array_equal(conversions.vvel_scale(a), a * -10)
     assert np.array_equal(conversions.vort_scale(a), a / 1E-05)
     assert np.array_equal(conversions.weasd_to_1hsnw(a), a * 10)
@@ -61,6 +62,7 @@ def test_conversion():
         conversions.ms_to_kt,
         conversions.pa_to_hpa,
         conversions.percent,
+        conversions.to_micro,
         conversions.vvel_scale,
         conversions.vort_scale,
         conversions.weasd_to_1hsnw,

--- a/tests/test_grib.py
+++ b/tests/test_grib.py
@@ -5,10 +5,12 @@ import datetime
 
 import numpy as np
 from matplotlib import colors as mcolors
-import xarray
+import xarray as xr
 
 import adb_graphics.datahandler.gribdata as gribdata
 import adb_graphics.datahandler.gribfile as gribfile
+
+DATAARRAY = xr.core.dataarray.DataArray
 
 def test_UPPData(natfile, prsfile):
 
@@ -33,7 +35,7 @@ def test_UPPData(natfile, prsfile):
         assert isinstance(upp.clevs, np.ndarray)
         assert isinstance(upp.date_to_str(datetime.datetime.now()), str)
         assert isinstance(upp.fhr, str)
-        assert isinstance(upp.field, xarray.DataArray)
+        assert isinstance(upp.field, DATAARRAY)
         assert isinstance(upp.latlons(), list)
         assert isinstance(upp.lev_descriptor, str)
         assert isinstance(upp.ncl_name(upp.vspec), str)
@@ -57,21 +59,21 @@ def test_fieldData(prsfile):
     assert isinstance(field.corners, list)
     assert isinstance(field.ticks, int)
     assert isinstance(field.units, str)
-    assert isinstance(field.values(), np.ndarray)
-    assert isinstance(field.aviation_flight_rules(field.values()), np.ndarray)
+    assert isinstance(field.values(), DATAARRAY)
+    assert isinstance(field.aviation_flight_rules(field.values()), DATAARRAY)
     assert isinstance(field.wind(True), list)
     assert len(field.corners) == 4
     assert len(field.wind(True)) == 2
     assert len(field.wind('850mb')) == 2
     for component in field.wind(True):
-        assert isinstance(component, np.ndarray)
+        assert isinstance(component, DATAARRAY)
 
     # Test retrieving other values
     assert np.array_equal(field.values(), field.values(name='temp', level='500mb'))
 
     # Return zeros by subtracting same field
     diff = field.field_diff(field.values(), variable2='temp', level2='500mb')
-    assert isinstance(diff, np.ndarray)
+    assert isinstance(diff, DATAARRAY)
     assert not np.any(diff)
 
     # Test transform
@@ -102,7 +104,7 @@ def test_profileData(natfile):
                                    )
 
     assert isinstance(profile.get_xypoint(40., -100.), tuple)
-    assert isinstance(profile.values(), xarray.DataArray)
+    assert isinstance(profile.values(), DATAARRAY)
 
     # The values should return a single number (0) or a 1D array (1)
     assert len(np.shape((profile.values(level='best', name='li')))) == 0


### PR DESCRIPTION
This set of changes fixes a memory leak issue we'd been seeing that does not allow running subdomains on smaller Jet partitions (sjet/vjet and tjet/ujet). Summary of major changes:

- Removed a lot of caching as parallel mode doesn't really use that allocated memory anyway.
- Explicitly cleaned up larger memory objects.
- Clear and close images explicitly once saved.

These changes have been tested for HRRR and RRFS CONUS on a variety of jet partitions with desirable results, most notably the completion of subdomains, even several subdomains.


