### PR TITLE
fix bug to allow all skewT info boxes to be plotted.

### DIFF
--- a/adb_graphics/figures/skewt.py
+++ b/adb_graphics/figures/skewt.py
@@ -179,7 +179,7 @@ class SkewTDiagram(gribdata.profileData):
                                          )
                           )
 
-        plt.legend(handles=handles, loc=[4.2, -0.8])
+        hydro_subplot.legend(handles=handles, loc=[0.05, 0.65])
 
         contents = '\n'.join(lines)
         # Draw the vertically integrated amounts box


### PR DESCRIPTION
This is a one-line fix to plot the hydrometeor legend plot.  The plot call was overwriting the hodograph plot settings.  The corrected call is based on the hydrometeor plotting coordinates so it doesn't overwrite.

passed pylint. pytest failed at my end, I think it may work in GitHub.

sample before and after plots below.

![image](https://user-images.githubusercontent.com/56739562/134991250-be2b1b24-a1fa-4978-8e7d-9becce27c14d.png)
![image](https://user-images.githubusercontent.com/56739562/134991291-e6253fca-200e-49dd-a66c-78d3097c8cf3.png)
