### PR TITLE
Combine prs and nat grib files.

### DIFF
--- a/create_graphics.py
+++ b/create_graphics.py
@@ -758,8 +758,11 @@ def graphics_driver(cla):
     # When accummulating variables for preparing a single lead time,
     # load all of those into gribfiles up front.
     # This is not an operational feature. Exit if files don't exist.
+
+    first_fcst = 6 if cla.images[0] == 'global' else 0
+    fcst_inc = 6 if cla.images[0] == 'global' else 1
     if len(cla.fcst_hour) == 1 and cla.all_leads:
-        for fhr in range(int(cla.fcst_hour[0])):
+        for fhr in range(first_fcst, int(cla.fcst_hour[0]), fcst_inc):
             grib_path, old_enough = pre_proc_grib_files(cla, fhr)
             if not os.path.exists(grib_path) or not old_enough:
                 msg = (f'File {grib_path} does not exist! Cannot accumulate',

--- a/pre.sh
+++ b/pre.sh
@@ -6,4 +6,6 @@ module use -a /contrib/miniconda3/modulefiles
 module load miniconda3
 conda activate pygraf
 
+module load wgrib2
+
 module list


### PR DESCRIPTION
This PR adds options to concatenate grib files when multiple paths and file templates are provided. When combined, the resulting file will also remove all duplicated entries. The script self-cleans those combined files upon exit. 

This work also addresses what should happen when a forecast hour is not found. If a grib input file is not found within the waiting period, all accumulated variables will be removed from the subsequent forecast hours, and all other images should be generated. 

The feature that allows accumulated variables to be plotted a single forecast lead time (an -all_leads flag with -f 6, for example), should now work as expected. If combining files in this mode, all files must be present. A real-time feature to wait on the file has been disabled since this this is not how real-time cases are run.

Should address Issues #94, #111, #85, and #84.
