### PR TITLE
correct field range and color table for uswrf

### DIFF
--- a/adb_graphics/default_specs.yml
+++ b/adb_graphics/default_specs.yml
@@ -1376,7 +1376,10 @@ ulwrf: # Upward Longwave Radiation Flux
 uswrf: # Upward Shortwave Radiation Flux
   sfc:
     <<: *radiation_flux
+    clevs: [0, 50, 100, 150, 200, 250, 300, 400, 500, 600, 700, 800, 900, 1000]
+    colors: rainbow12_colors
     ncl_name: USWRF_P0_L1_{grid}
+    ticks: 0
     title: Upward Shortwave Radiation Flux, Surface
   top: # Nominal top of atmosphere
     <<: *radiation_flux


### PR DESCRIPTION
The original default settings for upward shortwave radiation flux (uswrf) were copied from the longwave values, which is not correct.  I changed the range and color table to approximate the old NCL settings.

passed pylint and pytest on local machine.

sample before and after below.
![image](https://user-images.githubusercontent.com/56739562/140093582-0bf1d73d-86c6-45f7-81a2-cd971799abce.png)
![image](https://user-images.githubusercontent.com/56739562/140093601-90a84d6d-aa5c-4190-b091-25767042ea0b.png)
