### PR TITLE
update RRFS soil levels in image_list

### DIFF
--- a/image_lists/rrfs_subset.yml
+++ b/image_lists/rrfs_subset.yml
@@ -119,9 +119,14 @@ hourly:
       - sfc
     soilt: &soilt_levs
       - 0cm
+      - 1cm
+      - 4cm
       - 10cm
-      - 40cm
+      - 30cm
+      - 60cm
       - 1m
+      - 1.6m
+      - 3m
     soilw: *soilt_levs
     solar:
       - sfc


### PR DESCRIPTION
This resets the RRFS soil levels to the same 9 values as the HRRR.  It is in preparation for the upcoming  deployment which will change the levels from 4 to 9.

Testing using Eric's test file data.

Passed pylint and pytest.  No graphics comparison needed.