### PR TITLE
change color table to improve soilw comparisons

### DIFF
--- a/adb_graphics/default_specs.yml
+++ b/adb_graphics/default_specs.yml
@@ -1124,8 +1124,8 @@ soilt: # Soil Temperature
     title: Soil Temperature at 3m
 soilw: # Soil Moisture
   0cm: &soilw_levs
-    clevs: !!python/object/apply:numpy.arange [0.0, 0.61, 0.1]
-    cmap: gist_ncar
+    clevs: !!python/object/apply:numpy.arange [0.0, 0.51, 0.05]
+    cmap: jet_r
     colors: soilw_colors
     ncl_name: SOILW_P0_2L106_{grid}
     ticks: 0

--- a/adb_graphics/specs.py
+++ b/adb_graphics/specs.py
@@ -342,9 +342,9 @@ class VarSpec(abc.ABC):
 
         ''' Default color map for Soil Moisture '''
 
-        ncar = cm.get_cmap(self.vspec.get('cmap'), 128) \
-                          ([88, 83, 80, 70, 50, 25, 20, 15])
-        return ncar
+        grays = cm.get_cmap('Greys', 2)([1])
+        ncar = cm.get_cmap(self.vspec.get('cmap'), 110)(range(0,101,10))
+        return np.concatenate((grays, ncar))
 
     @property
     def t_colors(self) -> np.ndarray:

--- a/adb_graphics/specs.py
+++ b/adb_graphics/specs.py
@@ -343,7 +343,7 @@ class VarSpec(abc.ABC):
         ''' Default color map for Soil Moisture '''
 
         grays = cm.get_cmap('Greys', 2)([1])
-        ncar = cm.get_cmap(self.vspec.get('cmap'), 110)(range(0,101,10))
+        ncar = cm.get_cmap(self.vspec.get('cmap'), 110)(range(0, 101, 10))
         return np.concatenate((grays, ncar))
 
     @property


### PR DESCRIPTION
Tanya requested a change to the soilw color table to allow comparisons to other models.

Before and after sample plots below.

Passed pylint and pytest.

![image](https://user-images.githubusercontent.com/56739562/142664410-5f7753d4-52ea-4cdd-9894-9687ca4ea7ce.png)
![image](https://user-images.githubusercontent.com/56739562/142664420-67a0132e-bfea-429c-89b6-25f8920cb53e.png)
