### PR TITLE
change title for 10m Gust, include "Potential"

### DIFF
--- a/adb_graphics/default_specs.yml
+++ b/adb_graphics/default_specs.yml
@@ -575,6 +575,7 @@ gust:
     colors: wind_colors
     ncl_name: GUST_P0_L1_{grid}
     ticks: 5
+    title: 10m Wind Gust Potential
     transform: conversions.ms_to_kt
     unit: kt
 hail: # Max 1h Hail diameter


### PR DESCRIPTION
Stan requested a change to the 10m wind gust plot title, to make sure it included "Potential".

sample before and after plots below.

passed pylint and pytest

![image](https://user-images.githubusercontent.com/56739562/142694186-f47c0a45-9351-4b95-812a-103d290f54c7.png)

![image](https://user-images.githubusercontent.com/56739562/142694197-2fbe5ab2-889c-4ec6-b123-5145f5ae3712.png)
