### PR TITLE
sync snow color tables, adjust yellow/orange

### DIFF
--- a/adb_graphics/default_specs.yml
+++ b/adb_graphics/default_specs.yml
@@ -212,7 +212,7 @@ acsnod: # Accumulated snow
   sfc: &snow
     clevs: [0.01, 0.1, 1, 2, 3, 4, 6, 8, 10, 12, 18, 24]
     cmap: gist_ncar
-    colors: rainbow12_colors
+    colors: snow_colors
     ncl_name: ASNOW_P8_L1_GLC0_acc
     ticks: 0
     title: Run Total Accumulated Snow Depth - var dens

--- a/adb_graphics/specs.py
+++ b/adb_graphics/specs.py
@@ -326,7 +326,7 @@ class VarSpec(abc.ABC):
 
         grays = cm.get_cmap('Greys', 5)([0, 2])
         ncar = cm.get_cmap(self.vspec.get('cmap'), 128) \
-                          ([15, 18, 20, 25, 50, 60, 70, 80, 85, 90, 100])
+                          ([15, 18, 20, 25, 50, 60, 74, 81, 85, 90, 100])
         return np.concatenate((grays, ncar))
 
     @property


### PR DESCRIPTION
Ed Szoke requested two small changes for snow plots:
(1) sync so that all snow depth use the same color table. changed 1h "snod" vs full run "acsnod" accumulated, based on his preference.
(2) change the yellow color slightly to make levels clearer for colorblindness.

sample before and after shown below, for plots (old, then new) and colorblind perspective (new on top, old below).

passed pylint and pytest.

![image](https://user-images.githubusercontent.com/56739562/142802200-0ed57f7d-fd63-4116-92aa-83014df8f1ec.png)

![image](https://user-images.githubusercontent.com/56739562/142802213-8b771d8f-2f2a-4c8e-ac1f-4662bba47c9d.png)

<img width="736" alt="Screen Shot 2021-11-21 at 9 28 58 PM" src="https://user-images.githubusercontent.com/56739562/142802221-543fa665-bdd6-44fc-aced-952e07350c65.png">
)
