### PR TITLE
adjust blue end of soilw colors for more detail

### DIFF
--- a/adb_graphics/specs.py
+++ b/adb_graphics/specs.py
@@ -343,7 +343,8 @@ class VarSpec(abc.ABC):
         ''' Default color map for Soil Moisture '''
 
         grays = cm.get_cmap('Greys', 2)([1])
-        ncar = cm.get_cmap(self.vspec.get('cmap'), 110)(range(0, 101, 10))
+        ncar = cm.get_cmap(self.vspec.get('cmap'), 110) \
+               ([0, 10, 20, 30, 40, 50, 70, 75, 85, 95, 105])
         return np.concatenate((grays, ncar))
 
     @property


### PR DESCRIPTION
Tanya asked for a small change in the soilw color table, to make some of the greenish-blues more blue.  

Sample change below.  Will share it with Tanya in Slack while the GitHub test is running, and redo if she wants more changes.

passed pylint and pytest.

<img width="583" alt="Screen Shot 2021-11-23 at 12 26 42 PM" src="https://user-images.githubusercontent.com/56739562/143090701-57d2c9af-2a12-47b5-8c86-9e569fa3254b.png">
