### PR TITLE
new colors and added level for soilw

### DIFF
--- a/adb_graphics/default_specs.yml
+++ b/adb_graphics/default_specs.yml
@@ -1125,7 +1125,7 @@ soilt: # Soil Temperature
     title: Soil Temperature at 3m
 soilw: # Soil Moisture
   0cm: &soilw_levs
-    clevs: !!python/object/apply:numpy.arange [0.0, 0.51, 0.05]
+    clevs: [0, 0.01, 0.05, 0.10, 0.15, 0.20, 0.25, 0.30, 0.35, 0.40, 0.45, 0.50]
     cmap: jet_r
     colors: soilw_colors
     ncl_name: SOILW_P0_2L106_{grid}

--- a/adb_graphics/specs.py
+++ b/adb_graphics/specs.py
@@ -344,7 +344,7 @@ class VarSpec(abc.ABC):
 
         grays = cm.get_cmap('Greys', 2)([1])
         ncar = cm.get_cmap(self.vspec.get('cmap'), 110) \
-               ([0, 10, 20, 30, 40, 50, 70, 75, 85, 95, 105])
+               ([0, 10, 20, 25, 35, 40, 60, 73, 80, 85, 95, 105])
         return np.concatenate((grays, ncar))
 
     @property


### PR DESCRIPTION
Tanya asked for one more small tweak in the soil moisture (SOILW) colors.  As I was added that change, I realized I left out a level in the colors, so I added 0.01 and retweaked the colors to match the SMOPS color scheme.

Sample below.

Passed pylint and pytest.

![soilw colors](https://user-images.githubusercontent.com/56739562/143917106-d8941162-3a49-4e53-ae0e-462bc00fabab.png)

