### PR TITLE
change ncl_name for HRRR ceil_exp2

### DIFF
--- a/adb_graphics/default_specs.yml
+++ b/adb_graphics/default_specs.yml
@@ -334,7 +334,7 @@ ceilexp: # Ceiling - experimental
 ceilexp2: # Ceiling - experimental no.2
   ua:
     <<: *ceil
-    ncl_name: CEIL_P0_L2_{grid}
+    ncl_name: HGT_P0_L2_{grid}
     title: Ceiling (exp-2)
 cfrzr: # Categorical Freezing Rain
   sfc:


### PR DESCRIPTION
putting through a PR for a hot fix, to change the NCL_NAME for the HRRR ceil_exp2 field.  Has been running smoothly for a couple weeks.

passed pylint.  errors in pytest seem to be from my local setup, but will see if it has problems in the GitHub tests.
