### PR TITLE
update RAP soil levels from 4 to 9

### DIFF
--- a/image_lists/rap_subset.yml
+++ b/image_lists/rap_subset.yml
@@ -58,15 +58,17 @@ hourly:
       - sfc
     snod:
       - sfc
-    soilt:
-      - 1cm
-      - 4cm
-      - 10cm
-    soilw:
+    soilt: &soilt_levs
       - 0cm
       - 1cm
       - 4cm
       - 10cm
+      - 30cm
+      - 60cm
+      - 1m
+      - 1.6m
+      - 3m
+    soilw: *soilt_levs
     solar:
       - sfc
     temp:


### PR DESCRIPTION
putting through a PR for a hot fix, to update the RAP soil levels from 4 to 9. Has been running smoothly for a couple weeks.

passed pylint. errors in pytest seem to be from my local setup, but will see if it has problems in the GitHub tests.