### PR TITLE
adjust hydro table location in skewTs

### DIFF
--- a/adb_graphics/figures/skewt.py
+++ b/adb_graphics/figures/skewt.py
@@ -183,7 +183,7 @@ class SkewTDiagram(gribdata.profileData):
 
         contents = '\n'.join(lines)
         # Draw the vertically integrated amounts box
-        hydro_subplot.text(0.02, 0.90, contents,
+        hydro_subplot.text(0.02, 0.95, contents,
                            bbox=dict(facecolor='white', edgecolor='black', alpha=0.7),
                            fontproperties=fm.FontProperties(family='monospace'),
                            size=8,


### PR DESCRIPTION
putting through a PR for a hot fix, to re-position the table for vertically integrated hydrometeors in the skewT plots.  This was noticed while making ICICLE plots with RRFS but can be used for all skewTs.

passed pylint. errors in pytest seem to be from my local setup, but will see if it has problems in the GitHub tests.