### PR TITLE
 adjust wind colors to have less greens

### DIFF
--- a/adb_graphics/specs.py
+++ b/adb_graphics/specs.py
@@ -425,8 +425,9 @@ class VarSpec(abc.ABC):
         ''' Default color map for Wind Speed '''
 
         low = cm.get_cmap(self.vspec.get('cmap'), 129)(range(129, 109, -5))
-        high = cm.get_cmap(self.vspec.get('cmap'), 129)(range(18, 103, 6))
-        return np.concatenate((low, high))
+        high1 = cm.get_cmap(self.vspec.get('cmap'), 129)(range(16, 29, 3))
+        high2 = cm.get_cmap(self.vspec.get('cmap'), 129)(range(48, 103, 6))
+        return np.concatenate((low, high1, high2))
 
     @property
     def wind_colors_high(self) -> np.ndarray:
@@ -434,5 +435,6 @@ class VarSpec(abc.ABC):
         ''' Default color map for High Wind Speed '''
 
         low = cm.get_cmap(self.vspec.get('cmap'), 129)(range(129, 108, -7))
-        high = cm.get_cmap(self.vspec.get('cmap'), 129)(range(18, 95, 7))
-        return np.concatenate((low, high))
+        high1 = cm.get_cmap(self.vspec.get('cmap'), 129)(range(16, 29, 4))
+        high2 = cm.get_cmap(self.vspec.get('cmap'), 129)(range(46, 95, 7))
+        return np.concatenate((low, high1, high2))


### PR DESCRIPTION
a small change to the wind_colors and wind_colors_high color tables.  Stan had request that the mid range not have so many greens.  I adjust the lower end greens to be more blue.  Putting the PR through but may still tweak it if Stan has more comments.

sample plots below.

passed pylint. errors in pytest seem to be from my local setup, but will see if it has problems in the GitHub tests.

![Wind colors test](https://user-images.githubusercontent.com/56739562/146826120-44eae501-0377-480a-a794-5eee3c9829d3.png)

