### PR TITLE
add transform for sfc, 1000ft, and 6000ft smoke

### DIFF
--- a/adb_graphics/conversions.py
+++ b/adb_graphics/conversions.py
@@ -78,6 +78,12 @@ def to_micro(field, **kwargs):
 
     return field * 1E6
 
+def to_micrograms_per_m3(field, **kwargs):
+
+    ''' Convert field to micrograms per cubic meter '''
+
+    return field * 1E9
+
 def vvel_scale(field, **kwargs):
 
     ''' Scale vertical velocity for plotting  '''

--- a/adb_graphics/default_specs.yml
+++ b/adb_graphics/default_specs.yml
@@ -1333,6 +1333,7 @@ trc1:
     ncl_name: MASSDEN_P0_L105_{grid}
     ticks: 0
     title: 1000ft AGL Smoke
+    transform: conversions.to_micrograms_per_m3
     wind: True
     unit: $\mu g/m^3$
     vertical_index: 4
@@ -1345,6 +1346,7 @@ trc1:
     colors: smoke_colors
     ncl_name: MASSDEN_P0_L103_{grid}
     title: Near-Surface Smoke
+    transform: conversions.to_micrograms_per_m3
     ticks: 0
     unit: $\mu g/m^3$
     wind: 10m

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -47,6 +47,7 @@ def test_conversion():
     assert np.array_equal(conversions.pa_to_hpa(a), a / 100)
     assert np.array_equal(conversions.percent(a), a * 100)
     assert np.array_equal(conversions.to_micro(a), a * 1E6)
+    assert np.array_equal(conversions.to_micrograms_per_m3(a), a * 1E9)
     assert np.array_equal(conversions.vvel_scale(a), a * -10)
     assert np.array_equal(conversions.vort_scale(a), a / 1E-05)
     assert np.array_equal(conversions.weasd_to_1hsnw(a), a * 10)
@@ -63,6 +64,7 @@ def test_conversion():
         conversions.pa_to_hpa,
         conversions.percent,
         conversions.to_micro,
+        conversions.to_micrograms_per_m3,
         conversions.vvel_scale,
         conversions.vort_scale,
         conversions.weasd_to_1hsnw,


### PR DESCRIPTION
Due to a units change by NCEP, the values in the MASSDEN smoke fields needs to be multiplied by 1e+9 to convert to micrograms per cubic meter.  The new transform is added here.