### PR TITLE
Support for named "full" domains.

### DIFF
--- a/adb_graphics/figures/maps.py
+++ b/adb_graphics/figures/maps.py
@@ -20,6 +20,15 @@ import numpy as np
 
 import adb_graphics.utils as utils
 
+# FULL_TILES is a list strings that includes the labels GSL attaches to some of
+# the wgrib2 cutouts used for larger domains like RAP and RRFS NA.
+FULL_TILES = [
+    "AK",
+    "conus",
+    "full",
+    "hrrr",
+    "hrrrak",
+    ]
 # TILE_DEFS is a dict of dicts with predefined tiles specifying the corners of the grid
 #     to be plotted, and the stride and length of the wind barbs.
 # Order for corners: [lower left lat, upper right lat, lower left lon, upper right lon]
@@ -94,7 +103,7 @@ class Map():
         self.tile = kwargs.get('tile', 'full')
         self.airports = self.load_airports(airport_fn)
 
-        if self.tile in ['full', 'conus', 'AK',]:
+        if self.tile in FULL_TILES:
             self.corners = self.grid_info.pop('corners')
         else:
             self.corners = self.get_corners()
@@ -120,7 +129,7 @@ class Map():
                                 zorder=2,
                                 )
         else:
-            if self.model not in ['global'] and self.tile not in ['full', 'conus', 'AK']:
+            if self.model not in ['global'] and self.tile not in FULL_TILES:
                 self.m.drawcounties(antialiased=False,
                                     color='gray',
                                     linewidth=0.1,
@@ -523,22 +532,24 @@ class DataMap():
         model = self.model_name
         tile = self.map.tile
 
+        full_tile = tile in FULL_TILES
+
         # Set the stride and size of the barbs to be plotted with a masked array.
-        if self.map.m.projection == 'lcc' and tile == 'full':
+        if self.map.m.projection == 'lcc' and full_tile:
             if model == 'HRRR-HI':
                 stride = 12
                 length = 4
             else:
                 stride = 30
                 length = 5
-        elif self.map.m.projection == 'rotpole' and tile == 'full':
+        elif self.map.m.projection == 'rotpole' and full_tile:
             if model == 'RRFS_NA_3km':
                 stride = 50
                 length = 4
             else:
                 stride = 15
                 length = 4
-        elif self.map.model == 'global' and tile == 'full':
+        elif self.map.model == 'global' and full_tile:
             stride = 20
             length = 4
         else:

--- a/create_graphics.py
+++ b/create_graphics.py
@@ -360,7 +360,7 @@ def parse_args():
         help='The domains to plot. Choose from any of those listed. Special ' \
         'choices: full is full model output domain, and all is the full domain, ' \
         'plus all of the sub domains. ' \
-        f'Choices: {["full", "all", "conus", "AK"] + list(maps.TILE_DEFS.keys())}',
+        f'Choices: {["full", "all"] + maps.FULL_TILES + list(maps.TILE_DEFS.keys())}',
         nargs='+',
         )
     return parser.parse_args()
@@ -655,10 +655,11 @@ def remove_proc_grib_files(cla):
 
     combined_files = glob.glob(combined_fp)
 
-    print(f'Removing combined files: ')
-    for file_path in combined_files:
-        print(f'  {file_path}')
-        os.remove(file_path)
+    if combined_files:
+        print(f'Removing combined files: ')
+        for file_path in combined_files:
+            print(f'  {file_path}')
+            os.remove(file_path)
 
 def stage_zip_files(tiles, zip_dir):
 


### PR DESCRIPTION
Add support to recognize some grids that are wgrib2 cut outs. These named grids should plot the entirety of the data in the file and use the file metadata to decide the basemap, but still need to be differentiated as "sub domains" or "tiles" of a larger grid for the same modeling system. 

Here I am adding "hrrr" and "hrrrak" for consistency with real-time RRFS NA 3km runs.