### PR TITLE
Correct Title for Helicity 0-3km Plots

### DIFF
--- a/adb_graphics/default_specs.yml
+++ b/adb_graphics/default_specs.yml
@@ -692,7 +692,7 @@ hlcytot:
   mn03:
     <<: *hlcy_mn03
     accumulate: True
-    title: Run Total 0-6km Min Updraft Helicity
+    title: Run Total 0-3km Min Updraft Helicity
     transform: run_total
   mn16:
     <<: *hlcy_mn16
@@ -712,7 +712,7 @@ hlcytot:
   mx03:
     <<: *hlcy_mx03
     accumulate: True
-    title: Run Total 0-6km Max Updraft Helicity
+    title: Run Total 0-3km Max Updraft Helicity
     transform: run_total
   mx16:
     <<: *hlcy_mx16


### PR DESCRIPTION
Ed Szoke noticed while preparing slides that the 0-3km helicity fields are mislabelled as "0-6km".  Fixed in two places in default_specs.

Passed pylint.   No plots provided.