### PR TITLE
Set modules to exact versions. Default not supported.

### DIFF
--- a/pre.sh
+++ b/pre.sh
@@ -3,9 +3,9 @@
 module purge
 
 module use -a /contrib/miniconda3/modulefiles
-module load miniconda3
+module load miniconda3/4.5.12
 conda activate pygraf
 
-module load wgrib2
+module load wgrib2/0.1.9.6a
 
 module list


### PR DESCRIPTION
This change has been made on disk in many of the HRRR and RAP real time graphics. It will also need to be deployed for RRFS. 

Jet and Hera are going to discontinue support for default modules, and the exact version must be specified to avoid script failure. 

These are the versions of the modules that are listed in the log files.