### PR TITLE
add png_suffix for ctop/ceil to fix 48h Web bug

### DIFF
--- a/create_graphics.py
+++ b/create_graphics.py
@@ -468,7 +468,7 @@ def parallel_maps(cla, fhr, ds, level, model, spec, variable, workdir,
     dm.draw(show=True)
 
     # Build the output path
-    png_suffix = level if level != 'ua' else ''
+    png_suffix = level
     png_file = f'{variable}_{tile}_{png_suffix}_f{fhr:03d}.png'
     png_file = png_file.replace("__", "_")
     png_path = os.path.join(workdir, png_file)

--- a/create_graphics.py
+++ b/create_graphics.py
@@ -468,8 +468,7 @@ def parallel_maps(cla, fhr, ds, level, model, spec, variable, workdir,
     dm.draw(show=True)
 
     # Build the output path
-    png_suffix = level
-    png_file = f'{variable}_{tile}_{png_suffix}_f{fhr:03d}.png'
+    png_file = f'{variable}_{tile}_{level}_f{fhr:03d}.png'
     png_file = png_file.replace("__", "_")
     png_path = os.path.join(workdir, png_file)
 


### PR DESCRIPTION
For unknown reason, the lack of a `png_suffix` for some image names was causing those images to be lost for real time HRRR 48h forecast time. The plots were available and would populate the Web until the 48h file was added before all forecast hours would be lost.

The fields had a unique level, `ua`, which was not added to images for similarity to legacy plot names.  Removing the conditional for `ua` levels adds that suffix to the plots and clears up the issue.

Passed pylint.  No images required.