### PR TITLE
Write CSV files of vertical profiles when running SkewTs

### DIFF
--- a/adb_graphics/figure_builders.py
+++ b/adb_graphics/figure_builders.py
@@ -234,6 +234,15 @@ def parallel_skewt(cla, fhr, ds, site, workdir):
         format='png',
         orientation='landscape',
         )
+
+    start_time = cla.start_time.strftime('%Y%m%d%H')
+    csvfile = f"{skew.site_code}.{skew.site_num}.skewt.{start_time}_f{fhr:03d}.csv"
+    csv_path = os.path.join(workdir, csvfile)
+    print('*' * 80)
+    print(f"Creating csv file: {csv_path}")
+    print('*' * 80)
+    skew.create_csv(csv_path)
+
     plt.close()
 
 def set_figure(model_name, graphic_type, tile):

--- a/adb_graphics/utils.py
+++ b/adb_graphics/utils.py
@@ -55,44 +55,6 @@ def create_zip(files_to_zip, zipf):
         # Wait before trying to obtain the lock on the file
         time.sleep(5)
 
-import yaml
-
-
-def create_zip(png_files, zipf):
-
-    ''' Create a zip file. Use a locking mechanism -- write a lock file to disk. '''
-
-    lock_file = f'{zipf}._lock'
-    retry = 2
-    count = 0
-    while True:
-        if not os.path.exists(lock_file):
-            fd = open(lock_file, 'w')
-            print(f'Writing to zip file {zipf} for files like: {png_files[0][-10:]}')
-
-            try:
-                with zipfile.ZipFile(zipf, 'a', zipfile.ZIP_DEFLATED) as zfile:
-                    for png_file in png_files:
-                        if os.path.exists(png_file):
-                            zfile.write(png_file, os.path.basename(png_file))
-            except: # pylint: disable=bare-except
-                print(f'Error on writing zip file! {sys.exc_info()[0]}')
-                count += 1
-                if count >= retry:
-                    raise
-            else:
-                # When zipping is successful, remove png_files
-                for png_file in png_files:
-                    if os.path.exists(png_file):
-                        os.remove(png_file)
-            finally:
-                fd.close()
-                if os.path.exists(lock_file):
-                    os.remove(lock_file)
-            break
-        # Wait before trying to obtain the lock on the file
-        time.sleep(5)
-
 def fhr_list(args):
 
     '''

--- a/adb_graphics/utils.py
+++ b/adb_graphics/utils.py
@@ -13,8 +13,47 @@ from multiprocessing import Process
 import os
 import sys
 import time
+import zipfile
 
 import numpy as np
+import yaml
+
+
+def create_zip(files_to_zip, zipf):
+
+    ''' Create a zip file. Use a locking mechanism -- write a lock file to disk. '''
+
+    lock_file = f'{zipf}._lock'
+    retry = 2
+    count = 0
+    while True:
+        if not os.path.exists(lock_file):
+            fd = open(lock_file, 'w')
+            print(f'Writing to zip file {zipf} for files like: {files_to_zip[0][-10:]}')
+
+            try:
+                with zipfile.ZipFile(zipf, 'a', zipfile.ZIP_DEFLATED) as zfile:
+                    for file_to_zip in files_to_zip:
+                        if os.path.exists(file_to_zip):
+                            zfile.write(file_to_zip,
+                                        os.path.basename(file_to_zip))
+            except: # pylint: disable=bare-except
+                print(f'Error on writing zip file! {sys.exc_info()[0]}')
+                count += 1
+                if count >= retry:
+                    raise
+            else:
+                # When zipping is successful, remove files_to_zip
+                for file_to_zip in files_to_zip:
+                    if os.path.exists(file_to_zip):
+                        os.remove(file_to_zip)
+            finally:
+                fd.close()
+                if os.path.exists(lock_file):
+                    os.remove(lock_file)
+            break
+        # Wait before trying to obtain the lock on the file
+        time.sleep(5)
 
 import yaml
 
@@ -245,14 +284,14 @@ def uniq_wgrib2_list(inlist):
 
     return uniq_list
 
-def zip_pngs(fhr, workdir, zipfiles):
+def zip_products(fhr, workdir, zipfiles):
 
-    ''' Spin up a subprocess to zip all the png files into the staged zip files.
+    ''' Spin up a subprocess to zip all the product files into the staged zip files.
 
     Input:
 
         fhr         integer forecast hour
-        workdir     path to the png files
+        workdir     path to the product files
         zipfiles    dictionary of tile keys, and zip directory values.
 
     Output:
@@ -260,13 +299,18 @@ def zip_pngs(fhr, workdir, zipfiles):
     '''
 
     for tile, zipf in zipfiles.items():
-        png_files = glob.glob(os.path.join(workdir, f'*_{tile}_*{fhr:02d}.png'))
-        zip_proc = Process(group=None,
-                           target=create_zip,
-                           args=(png_files, zipf),
-                           )
-        zip_proc.start()
-        zip_proc.join()
+        if tile == 'skewt_csv':
+            file_tmpl = f'*.skewt.*_f{fhr:03d}.csv'
+        else:
+            file_tmpl = f'*_{tile}_*{fhr:02d}.png'
+        product_files = glob.glob(os.path.join(workdir, file_tmpl))
+        if product_files:
+            zip_proc = Process(group=None,
+                               target=create_zip,
+                               args=(product_files, zipf),
+                               )
+            zip_proc.start()
+            zip_proc.join()
 
 def load_specs(arg):
 

--- a/create_graphics.py
+++ b/create_graphics.py
@@ -511,6 +511,8 @@ def graphics_driver(cla):
     # Create an empty zip file
     if cla.zip_dir:
         tiles = cla.tiles if cla.graphic_type == "maps" else ['skewt']
+        if 'skewt' in tiles:
+            tiles.append('skewt_csv')
         zipfiles = stage_zip_files(tiles, cla.zip_dir)
 
     fcst_hours = copy.deepcopy(cla.fcst_hour)
@@ -615,7 +617,7 @@ def graphics_driver(cla):
 
             # Zip png files and remove the originals in a subprocess
             if cla.zip_dir:
-                utils.zip_pngs(fhr, workdir, zipfiles)
+                utils.zip_products(fhr, workdir, zipfiles)
 
             # Keep track of last time we did something useful
             timer_end = time.time()


### PR DESCRIPTION
This feature was contributed by @terraladwig in response to the need to deliver the vertical profiles in CSV format to downstream stakeholders in the Spring Experiment. These files will now be written by default when deployed, and zipped separately from the png files. 

The need is ultimately for RRFS and RTMA, but it shouldn't hurt to have this running for HRRR and RAP, too. It didn't take too many additional resources (compute or disk) and should be cleaned from disk with the existing cleaning processes.

A quick note...I have applied these changes as a patch from work I was doing in a separate branch and the git history on the current branch does not accurately reflect the contributors. My apologies for losing that commit history. If that is a problem, please let me know and I will attempt to preserve that history more accurately.