### PR TITLE
change default name for RRFS soilm variable

### DIFF
--- a/adb_graphics/default_specs.yml
+++ b/adb_graphics/default_specs.yml
@@ -1097,7 +1097,7 @@ soilm: # Soil Moisture Availability
       hrrrhi: MSTAV_P0_L106_{grid}
       hrrrcar: MSTAV_P0_L106_{grid}
       rap: MSTAV_P0_L106_{grid}
-      rrfs: SOILM_P0_2L106_{grid}
+      rrfs: MSTAV_P0_2L106_{grid}
     ticks: 0
     title: Soil Moisture Availability
     unit: "%"


### PR DESCRIPTION
Formalizing a hot fix to soil moisture availability (soilm).  RRFS variable name in default_specs needed to be changed.  Only one line of code.

Passed linter.
