### PR TITLE
use negative range and reversed colors for min hlcy

### DIFF
--- a/adb_graphics/default_specs.yml
+++ b/adb_graphics/default_specs.yml
@@ -623,33 +623,23 @@ hlcy: # Helicity
     ncl_name: UPHL_P0_2L103_{grid}
     split: True
     title: 2-5km Updraft Helicity
-  mn02: &hlcy_mn02 # Hourly minimum of updraft helicity over 0-2 km layer
-    <<: *hlcy
-    clevs: [-300,-275,-250,-225,-200,-175,-150,-125,-100,-75,-50,-25]
+  mn02: &hlcy_mn # Hourly minimum of updraft helicity over 0-2 km layer
+    clevs: !!python/object/apply:numpy.arange [-300, -24, 25]
+    cmap: gist_ncar
     colors: rainbow12_reverse
     ncl_name: VAR_0_7_200_P8_2L103_{grid}_min1h
     split: True
+    ticks: 25
     title: 0-2km Min Updraft Helicity (over prv hr)
+    unit: $m^2 / s^2$
   mn03: &hlcy_mn03 # Hourly minimum of updraft helicity over 0-3 km layer
-    <<: *hlcy
-    clevs: [-300,-275,-250,-225,-200,-175,-150,-125,-100,-75,-50,-25]
-    colors: rainbow12_reverse
-    ncl_name: VAR_0_7_200_P8_2L103_{grid}_min1h
-    split: True
+    <<: *hlcy_mn
     title: 0-3km Min Updraft Helicity (over prv hr)
   mn16: &hlcy_mn16 # Hourly minimum of updraft helicity over 1-6 km layer
-    <<: *hlcy
-    clevs: [-300,-275,-250,-225,-200,-175,-150,-125,-100,-75,-50,-25]
-    colors: rainbow12_reverse
-    ncl_name: VAR_0_7_200_P8_2L103_{grid}_min1h
-    split: True
+    <<: *hlcy_mn
     title: 1-6km Min Updraft Helicity (over prv hr)
   mn25: &hlcy_mn25 # Hourly minimum of updraft helicity over 2-5 km layer
-    <<: *hlcy
-    clevs: [-300,-275,-250,-225,-200,-175,-150,-125,-100,-75,-50,-25]
-    colors: rainbow12_reverse
-    split: True
-    ncl_name: VAR_0_7_200_P8_2L103_{grid}_min1h
+    <<: *hlcy_mn
     title: 2-5km Min Updraft Helicity (over prv hr)
   mx02: &hlcy_mx02 # Hourly maximum of updraft helicity over 0-2 km layer
     <<: *hlcy
@@ -695,7 +685,7 @@ hlcy: # Helicity
     title: 0-3 km Storm Relative Helicity
 hlcytot:
   mn02:
-    <<: *hlcy_mn02
+    <<: *hlcy_mn
     accumulate: True
     title: Run Total 0-2km Min Updraft Helicity
     transform: run_total

--- a/adb_graphics/default_specs.yml
+++ b/adb_graphics/default_specs.yml
@@ -625,27 +625,29 @@ hlcy: # Helicity
     title: 2-5km Updraft Helicity
   mn02: &hlcy_mn02 # Hourly minimum of updraft helicity over 0-2 km layer
     <<: *hlcy
-    clevs: !!python/object/apply:numpy.arange [12.5, 150.5, 12.5]
+    clevs: [-300,-275,-250,-225,-200,-175,-150,-125,-100,-75,-50,-25]
+    colors: rainbow12_reverse
     ncl_name: VAR_0_7_200_P8_2L103_{grid}_min1h
     split: True
-    ticks: 12.5
     title: 0-2km Min Updraft Helicity (over prv hr)
   mn03: &hlcy_mn03 # Hourly minimum of updraft helicity over 0-3 km layer
     <<: *hlcy
-    clevs: !!python/object/apply:numpy.arange [12.5, 150.5, 12.5]
+    clevs: [-300,-275,-250,-225,-200,-175,-150,-125,-100,-75,-50,-25]
+    colors: rainbow12_reverse
     ncl_name: VAR_0_7_200_P8_2L103_{grid}_min1h
     split: True
-    ticks: 12.5
     title: 0-3km Min Updraft Helicity (over prv hr)
   mn16: &hlcy_mn16 # Hourly minimum of updraft helicity over 1-6 km layer
     <<: *hlcy
-    clevs: !!python/object/apply:numpy.arange [25, 301, 25]
+    clevs: [-300,-275,-250,-225,-200,-175,-150,-125,-100,-75,-50,-25]
+    colors: rainbow12_reverse
     ncl_name: VAR_0_7_200_P8_2L103_{grid}_min1h
     split: True
     title: 1-6km Min Updraft Helicity (over prv hr)
   mn25: &hlcy_mn25 # Hourly minimum of updraft helicity over 2-5 km layer
     <<: *hlcy
-    clevs: !!python/object/apply:numpy.arange [25, 301, 25]
+    clevs: [-300,-275,-250,-225,-200,-175,-150,-125,-100,-75,-50,-25]
+    colors: rainbow12_reverse
     split: True
     ncl_name: VAR_0_7_200_P8_2L103_{grid}_min1h
     title: 2-5km Min Updraft Helicity (over prv hr)

--- a/adb_graphics/specs.py
+++ b/adb_graphics/specs.py
@@ -299,6 +299,16 @@ class VarSpec(abc.ABC):
         return np.concatenate((grays, ncar))
 
     @property
+    def rainbow12_reverse(self) -> np.ndarray:
+
+        ''' Default color map for min helicity '''
+
+        grays = cm.get_cmap('Greys', 2)([0])
+        ncar = cm.get_cmap(self.vspec.get('cmap'), 128) \
+                          ([120, 100, 90, 85, 80, 70, 60, 50, 25, 20, 18, 15])
+        return np.concatenate((ncar, grays))
+
+    @property
     def shear_colors(self) -> np.ndarray:
 
         ''' Default color map for Vertical Shear '''

--- a/adb_graphics/specs.py
+++ b/adb_graphics/specs.py
@@ -303,10 +303,7 @@ class VarSpec(abc.ABC):
 
         ''' Default color map for min helicity '''
 
-        grays = cm.get_cmap('Greys', 2)([0])
-        ncar = cm.get_cmap(self.vspec.get('cmap'), 128) \
-                          ([120, 100, 90, 85, 80, 70, 60, 50, 25, 20, 18, 15])
-        return np.concatenate((ncar, grays))
+        return np.flip(self.rainbow12_colors, 0)
 
     @property
     def shear_colors(self) -> np.ndarray:


### PR DESCRIPTION
Changes to defaults_specs.yml and specs.py to use negative range and a reversed color table for minimum helicity relative to max helicity.

Minimum helicity values are generally small and don't show in the field, however, David D. thought the range worked as a symmetry between max and min helicity graphics.  May need to revisit the range later if others want to see more detail.

Passed linter.