### PR TITLE
Changed default_specs.yml for GLC0 grid to {grid} for ceiling field designation.

### DIFF
--- a/adb_graphics/default_specs.yml
+++ b/adb_graphics/default_specs.yml
@@ -502,7 +502,7 @@ flru: # Aviation Flight Rules
     clevs: [0.0, 1.0, 2.0, 3.0, 4.0]
     cmap: gist_ncar
     colors: flru_colors
-    ncl_name: HGT_P0_L215_GLC0
+    ncl_name: HGT_P0_L215_{grid}
     ticks: 1
     title: Aviation Flight Rules
     transform:


### PR DESCRIPTION
The specific reference of GLC0 for ceiling caused problems in HRRR-AK, since it is a polar stereographic grid and requires that variables end in GST0.  Using the {grid} designation, this problem has been tested and resolved.