### PR TITLE
Set background color white for smoke plots

### DIFF
--- a/adb_graphics/specs.py
+++ b/adb_graphics/specs.py
@@ -320,10 +320,11 @@ class VarSpec(abc.ABC):
 
         ''' Default color map for smoke plots. '''
 
-        blues = cm.get_cmap('Blues', 6)(range(5))
+        white = cm.get_cmap('Greys', 2)([0])
+        blues = cm.get_cmap('Blues', 15)([2,5,8,11])
         green_yellow_red = cm.get_cmap('RdYlGn_r', 18)([1, 3, 5, 9, 12, 13, 14, 16, 18])
         purple = np.array([mpcolors.to_rgba('xkcd:vivid purple')])
-        return np.concatenate((blues, green_yellow_red, purple))
+        return np.concatenate((white,blues, green_yellow_red, purple))
 
 
     @property

--- a/adb_graphics/specs.py
+++ b/adb_graphics/specs.py
@@ -324,7 +324,7 @@ class VarSpec(abc.ABC):
         blues = cm.get_cmap('Blues', 6)(range(1, 5))
         green_yellow_red = cm.get_cmap('RdYlGn_r', 18)([1, 3, 5, 9, 12, 13, 14, 16, 18])
         purple = np.array([mpcolors.to_rgba('xkcd:vivid purple')])
-        return np.concatenate((white,blues, green_yellow_red, purple))
+        return np.concatenate((white, blues, green_yellow_red, purple))
 
 
     @property

--- a/adb_graphics/specs.py
+++ b/adb_graphics/specs.py
@@ -321,7 +321,7 @@ class VarSpec(abc.ABC):
         ''' Default color map for smoke plots. '''
 
         white = cm.get_cmap('Greys', 2)([0])
-        blues = cm.get_cmap('Blues', 15)([2,5,8,11])
+        blues = cm.get_cmap('Blues', 6)(range(1, 5))
         green_yellow_red = cm.get_cmap('RdYlGn_r', 18)([1, 3, 5, 9, 12, 13, 14, 16, 18])
         purple = np.array([mpcolors.to_rgba('xkcd:vivid purple')])
         return np.concatenate((white,blues, green_yellow_red, purple))


### PR DESCRIPTION
Changed the lowest value colors be actual white instead of pale blue for both integrated smoke and near surface smoke.

The following plots show the changes of the actual white (left) and original pale blue color (right):

<img width="1424" alt="smoke_int_before_after" src="https://user-images.githubusercontent.com/22350118/193351011-a9179eab-a707-4292-b661-29d63114600c.png">

<img width="1424" alt="smoke_sfc_before_after" src="https://user-images.githubusercontent.com/22350118/193351015-237c7bab-7d69-43c9-ab3b-7f8e2a33e229.png">

Please review.
