### PR TITLE
Vis colors update

### DIFF
--- a/adb_graphics/default_specs.yml
+++ b/adb_graphics/default_specs.yml
@@ -1470,10 +1470,11 @@ vil: # Vertically Integrated Liquid
     title: Vertically Integrated Liquid
 vis: # Visibility
   sfc:
-    clevs: !!python/object/apply:numpy.arange [0., 50., 0.1]
+    clevs: !join_ranges [[0, 10, 0.1], [10, 51, 1.0]]
     cmap: gist_ncar
     colors: vis_colors
     ncl_name: VIS_P0_L1_{grid}
+    ticks: -10
     title: Sfc Visibility
     transform: conversions.m_to_mi
     unit: mi

--- a/adb_graphics/default_specs.yml
+++ b/adb_graphics/default_specs.yml
@@ -1470,6 +1470,7 @@ vil: # Vertically Integrated Liquid
     title: Vertically Integrated Liquid
 vis: # Visibility
   sfc:
+    # see the description provided in adb_graphics/utils.py, for the join_ranges method.
     clevs: !join_ranges [[0, 10, 0.1], [10, 51, 1.0]]
     cmap: gist_ncar
     colors: vis_colors

--- a/adb_graphics/default_specs.yml
+++ b/adb_graphics/default_specs.yml
@@ -1470,11 +1470,10 @@ vil: # Vertically Integrated Liquid
     title: Vertically Integrated Liquid
 vis: # Visibility
   sfc:
-    clevs: !!python/object/apply:numpy.arange [0., 15., 0.1]
+    clevs: !!python/object/apply:numpy.arange [0., 50., 0.1]
     cmap: gist_ncar
     colors: vis_colors
     ncl_name: VIS_P0_L1_{grid}
-    ticks: -10
     title: Sfc Visibility
     transform: conversions.m_to_mi
     unit: mi

--- a/adb_graphics/specs.py
+++ b/adb_graphics/specs.py
@@ -396,6 +396,8 @@ class VarSpec(abc.ABC):
         IFR (Instrument Flight Rules) -- 1 mile to less than 3 miles
         MVFR (Marginal Visual Flight Rules) -- 3 to 5 miles
         VFR (Visual Flight Rules) -- greater than 5 miles
+
+        the gray range is arbitrary compared to the official flight levels
         '''
 
         lifr = cm.get_cmap('RdPu_r', 20)(range(0, 11))

--- a/adb_graphics/specs.py
+++ b/adb_graphics/specs.py
@@ -402,10 +402,10 @@ class VarSpec(abc.ABC):
         ifr = cm.get_cmap('autumn', 30)(range(0, 30))
         mvfr = cm.get_cmap('Blues', 20)(range(10, 20))
         vfr1 = cm.get_cmap('YlGn_r', 60)(range(0, 50))
-        vfr2 = cm.get_cmap('Greys', 20)(np.full(100, 9))
-        hi01 = cm.get_cmap('Greys', 20)(np.full(100, 6))
-        hi02 = cm.get_cmap('Greys', 20)(np.full(200, 3))
-        hi03 = cm.get_cmap('Greys', 20)(np.full(1, 0))
+        vfr2 = cm.get_cmap('Greys', 25)(np.full(10, 9))
+        hi01 = cm.get_cmap('Greys', 25)(np.full(10, 6))
+        hi02 = cm.get_cmap('Greys', 25)(np.full(20, 3))
+        hi03 = cm.get_cmap('Greys', 25)(np.full(1, 0))
 
         return np.concatenate((lifr, ifr, mvfr, vfr1, vfr2, hi01, hi02, hi03))
 

--- a/adb_graphics/specs.py
+++ b/adb_graphics/specs.py
@@ -398,7 +398,7 @@ class VarSpec(abc.ABC):
         VFR (Visual Flight Rules) -- greater than 5 miles
         '''
 
-        lifr = cm.get_cmap('RdPu_r', 20)(range(0, 10))
+        lifr = cm.get_cmap('RdPu_r', 20)(range(0, 11))
         ifr = cm.get_cmap('autumn', 30)(range(0, 30))
         mvfr = cm.get_cmap('Blues', 20)(range(10, 20))
         vfr1 = cm.get_cmap('YlGn_r', 60)(range(0, 50))

--- a/adb_graphics/specs.py
+++ b/adb_graphics/specs.py
@@ -398,13 +398,16 @@ class VarSpec(abc.ABC):
         VFR (Visual Flight Rules) -- greater than 5 miles
         '''
 
-        lifr = cm.get_cmap('RdPu_r', 20)(range(0, 11))
+        lifr = cm.get_cmap('RdPu_r', 20)(range(0, 10))
         ifr = cm.get_cmap('autumn', 30)(range(0, 30))
         mvfr = cm.get_cmap('Blues', 20)(range(10, 20))
         vfr1 = cm.get_cmap('YlGn_r', 60)(range(0, 50))
-        vfr2 = cm.get_cmap('Reds', 15)(np.full(51, 1))
+        vfr2 = cm.get_cmap('Greys', 20)(np.full(100, 9))
+        hi01 = cm.get_cmap('Greys', 20)(np.full(100, 6))
+        hi02 = cm.get_cmap('Greys', 20)(np.full(200, 3))
+        hi03 = cm.get_cmap('Greys', 20)(np.full(1, 0))
 
-        return np.concatenate((lifr, ifr, mvfr, vfr1, vfr2))
+        return np.concatenate((lifr, ifr, mvfr, vfr1, vfr2, hi01, hi02, hi03))
 
     @property
     def vvel_colors(self) -> np.ndarray:

--- a/adb_graphics/utils.py
+++ b/adb_graphics/utils.py
@@ -142,6 +142,7 @@ def join_ranges(loader, node):
 
     return np.concatenate(list_, axis=0)
 
+# SafeLoader doesn't seem compatible with our numpy contructors, using Loader here
 yaml.add_constructor("!join_ranges", join_ranges, Loader=yaml.Loader)
 
 # pylint: disable=invalid-name, too-many-locals

--- a/adb_graphics/utils.py
+++ b/adb_graphics/utils.py
@@ -115,12 +115,32 @@ def get_func(val: str):
     fun = getattr(module, fun_name)
     return fun
 
+# pylint: disable=unused-argument
 def join_ranges(loader, node):
 
-    ''' merge two different ranges into a single array for color bar clevs. '''
+    '''
+    Merge two or more different ranges into a single array for color bar clevs.
 
-    return np.concatenate((np.arange(0, 10, 0.1), np.arange(10, 51, 1.0)), axis=0)
+    e.g.: in default_specs.yml, clevs for visibility can be assigned as
 
+        clevs: !join_ranges [[0, 10, 0.1], [10, 51, 1.0]]
+
+    The join_ranges method concatenates these ranges into a single array of levels.
+    This can be useful for plots where one part of the color ranges requires higher
+    resolution than the rest, while keeping the colorbar from looking squished.
+
+    Note that a "yaml.add_constructor" is required, as shown after the method.
+    '''
+
+    list_ = []
+    for seq_node in node.value:
+        range_args = []
+        for scalar_node in seq_node.value:
+            range_args.append(float(scalar_node.value))
+
+        list_.append(np.arange(*range_args))
+
+    return np.concatenate(list_, axis=0)
 
 yaml.add_constructor("!join_ranges", join_ranges, Loader=yaml.Loader)
 

--- a/adb_graphics/utils.py
+++ b/adb_graphics/utils.py
@@ -115,6 +115,14 @@ def get_func(val: str):
     fun = getattr(module, fun_name)
     return fun
 
+def join_ranges(loader, node):
+
+    ''' merge two different ranges into a single array for color bar clevs. '''
+
+    return np.concatenate((np.arange(0, 10, 0.1), np.arange(10, 51, 1.0)), axis=0)
+
+
+yaml.add_constructor("!join_ranges", join_ranges, Loader=yaml.Loader)
 
 # pylint: disable=invalid-name, too-many-locals
 def label_line(ax, label, segment, **kwargs):

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -121,12 +121,21 @@ def test_join_ranges_constructor():
     yaml.add_constructor('!join_ranges', utils.join_ranges, Loader=yaml.SafeLoader)
     yaml_str = '''
     foo: !join_ranges [[0, 15, 0.1], [20, 61, 20]]
+    foo2: !join_ranges [[0, 15, 0.1]]
+    foo3: !join_ranges [[0, 15, 0.1], [20, 40, 10], [40, 61, 20]]
     '''
     cfg = yaml.load(yaml_str, Loader=yaml.SafeLoader)
 
-    expected = np.concatenate((np.arange(0, 15, 0.1), np.arange(20, 61, 20)), axis=0)
+    expected = np.concatenate((np.arange(0, 15, 0.1),
+                               np.arange(20, 61, 20)), axis=0)
+    expected2 = np.arange(0, 15, 0.1)
+    expected3 = np.concatenate((np.arange(0, 15, 0.1),
+                                np.arange(20, 40, 10),
+                                np.arange(40, 61, 20)), axis=0)
 
     assert np.array_equal(expected, cfg['foo'])
+    assert np.array_equal(expected2, cfg['foo2'])
+    assert np.array_equal(expected3, cfg['foo3'])
 
 
 class TestDefaultSpecs():

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -21,6 +21,7 @@ from matplotlib import cm
 from matplotlib import colors as mcolors
 from metpy.plots import ctables
 import numpy as np
+import yaml
 
 import adb_graphics.conversions as conversions
 import adb_graphics.specs as specs
@@ -111,6 +112,21 @@ def test_utils():
     ''' Test that utils works appropriately. '''
 
     assert callable(utils.get_func('conversions.k_to_c'))
+
+
+def test_join_ranges_constructor():
+
+    ''' Test that the join_ranges constructor works as expected. '''
+
+    yaml.add_constructor('!join_ranges', utils.join_ranges, Loader=yaml.SafeLoader)
+    yaml_str = '''
+    foo: !join_ranges [[0, 15, 0.1], [20, 61, 20]]
+    '''
+    cfg = yaml.load(yaml_str, Loader=yaml.SafeLoader)
+
+    expected = np.concatenate((np.arange(0, 15, 0.1), np.arange(20, 61, 20)), axis=0)
+
+    assert np.array_equal(expected, cfg['foo'])
 
 
 class TestDefaultSpecs():


### PR DESCRIPTION
This updates the visibility colors, as originally suggested by Stan Benjamin.  It add a lower-resolution color scheme in grays to the larger visibility range, to provide some additional detail.

The changes required a new util.py method, join_ranges, which concatenates a list of ranges from the default_specs.yml file.

Passed pylint test.

Sample original and new plots below (different date/times)
![image](https://user-images.githubusercontent.com/56739562/193970621-4c7f5b1f-bfd4-468e-860f-6acc765ee5de.png)
![image](https://user-images.githubusercontent.com/56739562/193970640-2f5a5a96-b108-4406-8e1d-7d62ecf42069.png)
