### PR TITLE
Updating MSLP color table.

### DIFF
--- a/adb_graphics/default_specs.yml
+++ b/adb_graphics/default_specs.yml
@@ -826,9 +826,9 @@ pres:
     transform: conversions.pa_to_hpa
     unit: hPa
   msl:
-    clevs: !!python/object/apply:numpy.arange [650, 1051, 4]
-    cmap: gist_ncar
-    colors: ps_colors
+    clevs: !!python/object/apply:numpy.arange [976, 1051, 4]
+    cmap: Spectral_r
+    colors: pmsl_colors
     ncl_name:
       global: PRMSL_P0_L101_{grid}
       globalAK: PRMSL_P0_L101_{grid}
@@ -840,9 +840,10 @@ pres:
       hrrrcar: MSLMA_P0_L101_{grid}
       rap: MSLMA_P0_L101_{grid}
       rrfs: PRMSL_P0_L101_{grid}
-    ticks: 20
+    ticks: 0
     transform: conversions.pa_to_hpa
     unit: hPa
+    wind: 10m
   ua:
     ncl_name: PRES_P0_L105_{grid}
 ptmp: # Potential temperature

--- a/adb_graphics/specs.py
+++ b/adb_graphics/specs.py
@@ -239,6 +239,16 @@ class VarSpec(abc.ABC):
         return np.concatenate((grays, ncar))
 
     @property
+    def pmsl_colors(self) -> np.ndarray:
+
+        ''' Default color map for Surface Pressure '''
+
+        ncolors = len(self.vspec.get('clevs'))
+        incr = 128 // ncolors
+        colors = cm.get_cmap(self.vspec.get('cmap'), 128)(range(incr, 128, incr))
+        return np.asarray(colors)
+
+    @property
     def ps_colors(self) -> np.ndarray:
 
         ''' Default color map for Surface Pressure '''


### PR DESCRIPTION
ASCEND Team Members requested changes to reflect Mean Sea Level Pressure that is similar to the ones produced at EMC. The original followed the surface pressure color scheme, which was not quite appropriate.

Before:
![image](https://user-images.githubusercontent.com/56881914/195668025-0217bca6-7e58-4808-8c92-4deec0babec7.png)

New Version:
![image](https://user-images.githubusercontent.com/56881914/195668065-0a7a7f27-4780-4f02-a7cf-98490d696f85.png)
