### PR TITLE
add RRFS FIP icing products

### DIFF
--- a/adb_graphics/datahandler/gribdata.py
+++ b/adb_graphics/datahandler/gribdata.py
@@ -100,6 +100,17 @@ class UPPData(specs.VarSpec):
 
         return self._get_field(self.ncl_name(self.vspec))
 
+    def field_column_max(self, values, variable, level, **kwargs):
+
+        # pylint: disable=unused-argument
+
+        ''' Returns the column max of the values. '''
+
+        vals = self.values(name=variable, level=level, one_lev=False)
+        maxvals = vals.max(axis=0)
+
+        return maxvals
+
     def field_diff(self, values, variable2, level2, **kwargs):
 
         # pylint: disable=unused-argument
@@ -111,17 +122,6 @@ class UPPData(specs.VarSpec):
         value2.close()
 
         return diff
-
-    def field_column_max(self, values, variable, **kwargs):
-
-        # pylint: disable=unused-argument
-
-        ''' Returns the column max of the values. '''
-
-        vals = self.values(name=variable, level='1000ft', one_lev=False)
-        maxvals = vals.max(axis=0)
-
-        return maxvals
 
     def field_mean(self, values, variable, levels, **kwargs):
 

--- a/adb_graphics/datahandler/gribdata.py
+++ b/adb_graphics/datahandler/gribdata.py
@@ -1,4 +1,4 @@
-# pylint: disable=invalid-name,too-few-public-methods
+# pylint: disable=invalid-name,too-few-public-methods, too-many-lines
 
 '''
 Classes that handle the specifics of grib files from UPP.
@@ -113,6 +113,8 @@ class UPPData(specs.VarSpec):
         return diff
 
     def field_column_max(self, values, variable, **kwargs):
+
+        # pylint: disable=unused-argument
 
         ''' Returns the column max of the values. '''
 

--- a/adb_graphics/datahandler/gribdata.py
+++ b/adb_graphics/datahandler/gribdata.py
@@ -112,6 +112,15 @@ class UPPData(specs.VarSpec):
 
         return diff
 
+    def field_column_max(self, variable, **kwargs):
+
+        ''' Returns the column max of the values. '''
+
+        icprb = self.values(name='sipd', level='1000ft', one_lev=False)
+        maxvals = icprb.max(axis=0)
+
+        return maxvals
+
     def field_mean(self, values, variable, levels, **kwargs):
 
         # pylint: disable=unused-argument

--- a/adb_graphics/datahandler/gribdata.py
+++ b/adb_graphics/datahandler/gribdata.py
@@ -112,12 +112,12 @@ class UPPData(specs.VarSpec):
 
         return diff
 
-    def field_column_max(self, variable, **kwargs):
+    def field_column_max(self, values, variable, **kwargs):
 
         ''' Returns the column max of the values. '''
 
-        icprb = self.values(name='sipd', level='1000ft', one_lev=False)
-        maxvals = icprb.max(axis=0)
+        vals = self.values(name=variable, level='1000ft', one_lev=False)
+        maxvals = vals.max(axis=0)
 
         return maxvals
 

--- a/adb_graphics/datahandler/gribdata.py
+++ b/adb_graphics/datahandler/gribdata.py
@@ -1,4 +1,4 @@
-# pylint: disable=invalid-name,too-few-public-methods, too-many-public-methods, too-many-lines
+# pylint: disable=invalid-name, too-many-public-methods, too-many-lines
 
 '''
 Classes that handle the specifics of grib files from UPP.

--- a/adb_graphics/datahandler/gribdata.py
+++ b/adb_graphics/datahandler/gribdata.py
@@ -305,6 +305,16 @@ class UPPData(specs.VarSpec):
         return 'GRID NOT FOUND'
 
 
+    def icing_adjust_trace(self, values, **kwargs):
+
+        # pylint: disable=unused-argument
+
+        ''' Changes the value of ICSEV trace from 4.0 to 0.5, to maintain ascending order '''
+
+        vals = np.where(values == 4.0, 0.5, values)
+
+        return vals
+
     def latlons(self):
 
         ''' Returns the set of latitudes and longitudes '''

--- a/adb_graphics/datahandler/gribdata.py
+++ b/adb_graphics/datahandler/gribdata.py
@@ -659,10 +659,9 @@ class fieldData(UPPData):
 
         return grid_info
 
-    @staticmethod
-    def icing_adjust_trace(values, **kwargs):
+    def icing_adjust_trace(self, values, **kwargs):
 
-        # pylint: disable=unused-argument
+        # pylint: disable=unused-argument,no-self-use
 
         ''' Changes the value of ICSEV trace from 4.0 to 0.5, to maintain ascending order '''
 

--- a/adb_graphics/datahandler/gribdata.py
+++ b/adb_graphics/datahandler/gribdata.py
@@ -1,4 +1,4 @@
-# pylint: disable=invalid-name,too-few-public-methods, too-many-lines
+# pylint: disable=invalid-name,too-few-public-methods, too-many-public-methods, too-many-lines
 
 '''
 Classes that handle the specifics of grib files from UPP.
@@ -304,16 +304,6 @@ class UPPData(specs.VarSpec):
                     return sub
         return 'GRID NOT FOUND'
 
-
-    def icing_adjust_trace(self, values, **kwargs):
-
-        # pylint: disable=unused-argument
-
-        ''' Changes the value of ICSEV trace from 4.0 to 0.5, to maintain ascending order '''
-
-        vals = np.where(values == 4.0, 0.5, values)
-
-        return vals
 
     def latlons(self):
 
@@ -668,6 +658,17 @@ class fieldData(UPPData):
         del lat
 
         return grid_info
+
+    @staticmethod
+    def icing_adjust_trace(values, **kwargs):
+
+        # pylint: disable=unused-argument
+
+        ''' Changes the value of ICSEV trace from 4.0 to 0.5, to maintain ascending order '''
+
+        vals = np.where(values == 4.0, 0.5, values)
+
+        return vals
 
     def run_total(self, values, **kwargs):
 

--- a/adb_graphics/default_specs.yml
+++ b/adb_graphics/default_specs.yml
@@ -765,6 +765,7 @@ icprb: # Icing Probability
     transform: 
       funcs: field_column_max
       kwargs:
+        level: 1000ft
         variable: icprb
 icsev: # Icing Severity
   500ft: &icsev
@@ -790,6 +791,7 @@ icsev: # Icing Severity
     transform: 
       funcs: field_column_max
       kwargs:
+        level: 1000ft
         variable: icsev
 lcl: # Lifted condensation level
   sfc: &lcl
@@ -1043,6 +1045,13 @@ rh: # Relative Humidity
       pres_sfc:
         hatches: ['', '...']
         levels: [0, 850]
+  max:
+    <<: *rh
+    transform:
+      funcs: field_column_max
+      kwargs:
+        level: 700mb
+        variable: rh
   mean: # Mean RH 850mb to 500mb
     <<: *rh
     print_units: false
@@ -1135,6 +1144,7 @@ sipd: # Supercooled Large Droplet Icing
     transform: 
       funcs: field_column_max
       kwargs:
+        level: 1000ft
         variable: sipd
 slw: # Supercooled Liquid Water
   sfc:

--- a/adb_graphics/default_specs.yml
+++ b/adb_graphics/default_specs.yml
@@ -742,11 +742,13 @@ icmr: # Ice Water Mixing Ratio
       prs: ICMR_P0_L100_{grid}
 icprb: # Icing Probability
   500ft: &icprb
-    clevs: !!python/object/apply:numpy.arange [0.05, 0.86, 0.10]
+    clevs: !!python/object/apply:numpy.arange [5, 86, 10]
     cmap: gist_ncar
     colors: icprb_colors
     ncl_name: ICPRB_P0_L102_{grid}
-    ticks: 0.1
+    ticks: 10
+    transform: conversions.percent
+    unit: "%"
     vertical_index: 0   # grib2 vertical levels are in meters,
                         # so using index here to avoid errors from conversions
   1000ft:
@@ -1097,11 +1099,13 @@ shtfl: # Sensible Heat Net Flux
     unit: W/m$^{2}$
 sipd: # Supercooled Large Droplet Icing
   500ft: &sipd
-    clevs: [0, .10, .20, .30, .40, .50, .60, .70, .80, .90, 1.0, 1.1]
+    clevs: !!python/object/apply:numpy.arange [5, 86, 10]
     cmap: gist_ncar
-    colors: rainbow12_colors
+    colors: icprb_colors
     ncl_name: SIPD_P0_L102_{grid}
-    ticks: 0.1
+    ticks: 10
+    transform: conversions.percent
+    unit: "%"
     vertical_index: 0   # grib2 vertical levels are in meters,
                         # so using index here to avoid errors from conversions
   1000ft:

--- a/adb_graphics/default_specs.yml
+++ b/adb_graphics/default_specs.yml
@@ -773,6 +773,7 @@ icsev: # Icing Severity
     colors: icsev_colors
     ncl_name: ICSEV_P0_L102_{grid}
     ticks: 0
+    transform: icing_adjust_trace
     vertical_index: 0   # grib2 vertical levels are in meters,
                         # so using index here to avoid errors from conversions
   1000ft:

--- a/adb_graphics/default_specs.yml
+++ b/adb_graphics/default_specs.yml
@@ -740,6 +740,42 @@ icmr: # Ice Water Mixing Ratio
         - ICMR_P0_L105_{grid}
         - CIMIXR_P0_L105_{grid}
       prs: ICMR_P0_L100_{grid}
+icprb: # Icing Probability
+  500ft: &icprb
+    clevs: !!python/object/apply:numpy.arange [0.05, 0.86, 0.10]
+    cmap: gist_ncar
+    colors: icprb_colors
+    ncl_name: ICPRB_P0_L102_{grid}
+    ticks: 0.1
+    vertical_index: 0   # grib2 vertical levels are in meters,
+                        # so using index here to avoid errors from conversions
+  1000ft:
+    <<: *icprb
+    vertical_index: 1
+  9000ft:
+    <<: *icprb
+    vertical_index: 17
+  15000ft:
+    <<: *icprb
+    vertical_index: 29
+icsev: # Icing Severity
+  500ft: &icsev
+    clevs: [0.0, 0.5, 1.0, 2.0, 3.0]
+    cmap: Blues
+    colors: icsev_colors
+    ncl_name: ICSEV_P0_L102_{grid}
+    ticks: 0
+    vertical_index: 0   # grib2 vertical levels are in meters,
+                        # so using index here to avoid errors from conversions
+  1000ft:
+    <<: *icsev
+    vertical_index: 1
+  9000ft:
+    <<: *icsev
+    vertical_index: 17
+  15000ft:
+    <<: *icsev
+    vertical_index: 29
 lcl: # Lifted condensation level
   sfc: &lcl
     clevs: !!python/object/apply:numpy.arange [0, 5000, 250]
@@ -1059,6 +1095,24 @@ shtfl: # Sensible Heat Net Flux
     ticks: 0
     title: Sensible Heat Net Flux
     unit: W/m$^{2}$
+sipd: # Supercooled Large Droplet Icing
+  500ft: &sipd
+    clevs: [0, .10, .20, .30, .40, .50, .60, .70, .80, .90, 1.0, 1.1]
+    cmap: gist_ncar
+    colors: rainbow12_colors
+    ncl_name: SIPD_P0_L102_{grid}
+    ticks: 0.1
+    vertical_index: 0   # grib2 vertical levels are in meters,
+                        # so using index here to avoid errors from conversions
+  1000ft:
+    <<: *sipd
+    vertical_index: 1
+  9000ft:
+    <<: *sipd
+    vertical_index: 17
+  15000ft:
+    <<: *sipd
+    vertical_index: 29
 slw: # Supercooled Liquid Water
   sfc:
     clevs: [0.05, 0.1, 0.2, .3, .4, .5, .75, 1., 1.25, 1.5, 2., 3., 4., 5., 6.]

--- a/adb_graphics/default_specs.yml
+++ b/adb_graphics/default_specs.yml
@@ -760,6 +760,12 @@ icprb: # Icing Probability
   15000ft:
     <<: *icprb
     vertical_index: 29
+  max:
+    <<: *icprb
+    transform:
+      funcs: field_column_max
+      kwargs:
+        variable2: icprb
 icsev: # Icing Severity
   500ft: &icsev
     clevs: [0.0, 0.5, 1.0, 2.0, 3.0]
@@ -778,6 +784,12 @@ icsev: # Icing Severity
   15000ft:
     <<: *icsev
     vertical_index: 29
+  max:
+    <<: *icsev
+    transform:
+      funcs: field_column_max
+      kwargs:
+        variable2: icsev
 lcl: # Lifted condensation level
   sfc: &lcl
     clevs: !!python/object/apply:numpy.arange [0, 5000, 250]
@@ -1117,6 +1129,9 @@ sipd: # Supercooled Large Droplet Icing
   15000ft:
     <<: *sipd
     vertical_index: 29
+  max:
+    <<: *sipd
+    transform: field_column_max
 slw: # Supercooled Liquid Water
   sfc:
     clevs: [0.05, 0.1, 0.2, .3, .4, .5, .75, 1., 1.25, 1.5, 2., 3., 4., 5., 6.]

--- a/adb_graphics/default_specs.yml
+++ b/adb_graphics/default_specs.yml
@@ -762,10 +762,10 @@ icprb: # Icing Probability
     vertical_index: 29
   max:
     <<: *icprb
-    transform:
+    transform: 
       funcs: field_column_max
       kwargs:
-        variable2: icprb
+        variable: icprb
 icsev: # Icing Severity
   500ft: &icsev
     clevs: [0.0, 0.5, 1.0, 2.0, 3.0]
@@ -786,10 +786,10 @@ icsev: # Icing Severity
     vertical_index: 29
   max:
     <<: *icsev
-    transform:
+    transform: 
       funcs: field_column_max
       kwargs:
-        variable2: icsev
+        variable: icsev
 lcl: # Lifted condensation level
   sfc: &lcl
     clevs: !!python/object/apply:numpy.arange [0, 5000, 250]
@@ -1131,7 +1131,10 @@ sipd: # Supercooled Large Droplet Icing
     vertical_index: 29
   max:
     <<: *sipd
-    transform: field_column_max
+    transform: 
+      funcs: field_column_max
+      kwargs:
+        variable: sipd
 slw: # Supercooled Liquid Water
   sfc:
     clevs: [0.05, 0.1, 0.2, .3, .4, .5, .75, 1., 1.25, 1.5, 2., 3., 4., 5., 6.]

--- a/adb_graphics/default_specs.yml
+++ b/adb_graphics/default_specs.yml
@@ -741,6 +741,8 @@ icmr: # Ice Water Mixing Ratio
         - CIMIXR_P0_L105_{grid}
       prs: ICMR_P0_L100_{grid}
 icprb: # Icing Probability
+  # levels chosen are arbitrary based on initial plot samples
+  # additional levels may be requested in the future.
   500ft: &icprb
     clevs: !!python/object/apply:numpy.arange [5, 86, 10]
     cmap: gist_ncar
@@ -768,7 +770,12 @@ icprb: # Icing Probability
         level: 1000ft
         variable: icprb
 icsev: # Icing Severity
+  # levels chosen are arbitrary based on initial plot samples
+  # additional levels may be requested in the future.
   500ft: &icsev
+    # these clevs get mapped into categorical levels in maps.py
+    # the data 0.5 level is out of proper order for plotting, this
+    # is also handled in maps.py
     clevs: [0.0, 0.5, 1.0, 2.0, 3.0]
     cmap: Blues
     colors: icsev_colors
@@ -1120,6 +1127,8 @@ shtfl: # Sensible Heat Net Flux
     title: Sensible Heat Net Flux
     unit: W/m$^{2}$
 sipd: # Supercooled Large Droplet Icing
+  # levels chosen are arbitrary based on initial plot samples
+  # additional levels may be requested in the future.
   500ft: &sipd
     clevs: !!python/object/apply:numpy.arange [5, 86, 10]
     cmap: gist_ncar

--- a/adb_graphics/figures/maps.py
+++ b/adb_graphics/figures/maps.py
@@ -283,6 +283,10 @@ class DataMap():
         if self.field.short_name == 'flru':
             ticks = [label.rjust(30) for label in ['VFR', 'MVFR', 'IFR', 'LIFR']]
 
+        # this step is done to allow proper order of icing severity levels (trace before light)
+        if self.field.short_name == 'icsev':
+            ticks = [label.rjust(30) for label in ['TRACE', 'LIGHT', 'MODERATE', 'HEAVY']]
+
         cbar.ax.set_xticklabels(ticks, fontsize=12)
 
     def draw(self, show=False):
@@ -393,6 +397,10 @@ class DataMap():
 
         x, y = self._xy_mesh(field)
         vals = field.values()
+
+        # this step is done to allow proper order of icing severity levels (trace before light)
+        if self.field.short_name == 'icsev':
+            vals = np.where(vals == 4.0, 0.5, vals)
 
         # For global lat-lon models, make 2D arrays for x and y
         # Shift the map and data if needed

--- a/adb_graphics/figures/maps.py
+++ b/adb_graphics/figures/maps.py
@@ -398,10 +398,6 @@ class DataMap():
         x, y = self._xy_mesh(field)
         vals = field.values()
 
-        # this step is done to allow proper order of icing severity levels (trace before light)
-        if self.field.short_name == 'icsev':
-            vals = np.where(vals == 4.0, 0.5, vals)
-
         # For global lat-lon models, make 2D arrays for x and y
         # Shift the map and data if needed
         if self.map.model in ['global']:

--- a/adb_graphics/specs.py
+++ b/adb_graphics/specs.py
@@ -174,6 +174,25 @@ class VarSpec(abc.ABC):
         return np.concatenate((grays, ctable))
 
     @property
+    def icprb_colors(self) -> np.ndarray:
+
+        ''' Default color map for Icing Probability '''
+
+        grays = cm.get_cmap('Greys', 2)([0])
+        ncar = cm.get_cmap(self.vspec.get('cmap'), 128) \
+                          ([25, 35, 50, 60, 70, 80, 85, 90, 100])
+        return np.concatenate((grays, ncar))
+
+    def icsev_colors(self) -> np.ndarray:
+
+        ''' Default color map for Icing  Severity '''
+
+        white = cm.get_cmap('Greys', 2)([0])
+        blues = cm.get_cmap(self.vspec.get('cmap'), 9) \
+                          ([2, 3, 4, 6, 8])
+        return np.concatenate((white, blues))
+
+    @property
     def lcl_colors(self) -> np.ndarray:
 
         ''' Default color map for Lifted Condensation Level '''

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -287,12 +287,14 @@ class TestDefaultSpecs():
         # Check datahandler.gribdata objects if a single word is provided
         if len(func.split('.')) == 1:
 
-            funcs = []
+            # Check all the classes in the gribdata module
             for attr in dir(gribdata):
                 # pylint: disable=no-member
+                # Check the methods in each class
                 if func in dir(gribdata.__getattribute__(attr)):
-                    funcs.append(gribdata.__getattribute__(attr).__dict__.get(func))
-            return funcs
+                    method = gribdata.__getattribute__(attr).__dict__.get(func)
+                    if method is not None:
+                        return method
 
         if callable(utils.get_func(func)):
             return utils.get_func(func)


### PR DESCRIPTION
This update adds new icing products to the main python graphics repository.  The products include Icing Probability (icprb), Icing Severity (icsev), and Supercooled Large Droplet Icing (sipd).   There are 60 vertical levels, in 500' increments up to 30,000ft.  Awaiting confirmation on which levels to plot by default, and will adjust _default_specs.yml_ accordingly.

This update also includes a new method in gribdata.py to compute the column_max for any field.  Testing should already be included in the current test_common.py steps.

Passed pylint and pytest.

sample plots:
![Presentation2](https://user-images.githubusercontent.com/56739562/197856393-e06ee078-e49d-4a6e-a19a-5b5cbe69035e.jpg)

