### PR TITLE
RRFS smoke & dust

### DIFF
--- a/adb_graphics/default_specs.yml
+++ b/adb_graphics/default_specs.yml
@@ -455,6 +455,26 @@ dewp: # Dew point temperature
     transform: conversions.k_to_f
     unit: F
     wind: 10m
+dust:
+  int:
+    clevs: [1, 4, 7, 11, 15, 20, 25, 30, 40, 50, 75, 150, 250, 500]
+    colors: smoke_colors
+    ncl_name: COLMD_P48_L200_{grid}_A62001
+    plot_airports: False
+    ticks: 0
+    title: Vertically Integrated Dust
+    transform: conversions.to_micro
+    unit: $mg/m^2$
+  sfc:
+    clevs: [1, 2, 4, 6, 8, 12, 16, 20, 25, 30, 40, 60, 100, 200]
+    colors: smoke_colors
+    ncl_name: MASSDEN_P48_L103_{grid}_A62001
+    plot_airports: False
+    title: Near-Surface Dust
+    transform: conversions.to_micrograms_per_m3
+    ticks: 0
+    unit: $\mu g/m^3$
+    wind: 10m
 echotop: # Echo Top
   sfc:
     clevs: !!python/object/apply:numpy.arange [4, 50, 3]
@@ -1329,7 +1349,10 @@ trc1:
   int:
     clevs: [1, 4, 7, 11, 15, 20, 25, 30, 40, 50, 75, 150, 250, 500]
     colors: smoke_colors
-    ncl_name: COLMD_P0_L200_{grid}
+    ncl_name:
+      hrrr:  COLMD_P0_L200_{grid}
+      rap:  COLMD_P0_L200_{grid}
+      rrfs: COLMD_P48_L200_{grid}_A62010
     plot_airports: False
     ticks: 0
     title: Vertically Integrated Smoke
@@ -1353,7 +1376,10 @@ trc1:
   sfc:
     clevs: [1, 2, 4, 6, 8, 12, 16, 20, 25, 30, 40, 60, 100, 200]
     colors: smoke_colors
-    ncl_name: MASSDEN_P0_L103_{grid}
+    ncl_name:
+      hrrr: MASSDEN_P0_L103_{grid}
+      rap: MASSDEN_P0_L103_{grid}
+      rrfs: MASSDEN_P48_L103_{grid}_A62010
     plot_airports: False
     title: Near-Surface Smoke
     transform: conversions.to_micrograms_per_m3

--- a/adb_graphics/default_specs.yml
+++ b/adb_graphics/default_specs.yml
@@ -457,7 +457,7 @@ dewp: # Dew point temperature
     wind: 10m
 dust:
   int:
-    clevs: [1, 4, 7, 11, 15, 20, 25, 30, 40, 50, 75, 150, 250, 500]
+    clevs: [0.5, 1, 2, 3, 4, 6, 8, 10, 15, 20, 30, 50, 100, 200]
     colors: smoke_colors
     ncl_name: COLMD_P48_L200_{grid}_A62001
     plot_airports: False
@@ -466,7 +466,7 @@ dust:
     transform: conversions.to_micro
     unit: $mg/m^2$
   sfc:
-    clevs: [1, 2, 4, 6, 8, 12, 16, 20, 25, 30, 40, 60, 100, 200]
+    clevs: [0.5, 1, 2, 3, 4, 6, 8, 10, 12, 15, 20, 30, 50, 100]
     colors: smoke_colors
     ncl_name: MASSDEN_P48_L103_{grid}_A62001
     plot_airports: False

--- a/image_lists/rrfs_subset.yml
+++ b/image_lists/rrfs_subset.yml
@@ -42,6 +42,9 @@ hourly:
       - ua
     dewp:
       - 2m
+    dust:
+      - int
+      - sfc
     echotop:
       - sfc
     firewx:
@@ -141,6 +144,9 @@ hourly:
       - 925mb
       - sfc
     totp:
+      - sfc
+    trc1:
+      - int
       - sfc
     ulwrf:
       - sfc


### PR DESCRIPTION
Additions to enable plotting of the new RRFS smoke and dust fields.  Dust is plotted with the same settings as smoke.

![image](https://user-images.githubusercontent.com/58485074/198334416-12cabae7-3eae-451e-8793-c2063d8d8f48.png)

![image](https://user-images.githubusercontent.com/58485074/198334483-b0a69be5-b757-4716-922d-3973fec94b14.png)

![image](https://user-images.githubusercontent.com/58485074/198334632-98db8adb-2c87-4fcd-82bf-ce28610a7294.png)

![image](https://user-images.githubusercontent.com/58485074/198334732-d42b14e8-e84a-4ce0-ba07-a7da22bf4408.png)
