### PR TITLE
Revisions to HWP and dust

### DIFF
--- a/adb_graphics/default_specs.yml
+++ b/adb_graphics/default_specs.yml
@@ -457,7 +457,7 @@ dewp: # Dew point temperature
     wind: 10m
 dust:
   int:
-    clevs: [0.5, 1, 2, 3, 4, 6, 8, 10, 15, 20, 30, 50, 100, 200]
+    clevs: [1, 2, 3, 4, 6, 8, 10, 15, 20, 30, 50, 75, 110, 150]
     colors: smoke_colors
     ncl_name: COLMD_P48_L200_{grid}_A62001
     plot_airports: False
@@ -466,7 +466,7 @@ dust:
     transform: conversions.to_micro
     unit: $mg/m^2$
   sfc:
-    clevs: [0.5, 1, 2, 3, 4, 6, 8, 10, 12, 15, 20, 30, 50, 100]
+    clevs: [1, 2, 3, 4, 6, 8, 10, 12, 15, 20, 30, 50, 75, 100]
     colors: smoke_colors
     ncl_name: MASSDEN_P48_L103_{grid}_A62001
     plot_airports: False
@@ -509,9 +509,9 @@ ffldro: # Ensemble flash flood runoff
     title: Prob of 6-hr Precip > RFC flash flood guidance w/in 40 km
 firewx: # Fire Weather Index
   sfc:
-    clevs: [0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 95, 100]
+    clevs: [10, 20, 30, 40, 50, 60, 70, 80, 90, 95, 100]
     cmap: gist_ncar
-    colors: rainbow12_colors
+    colors: rainbow11_colors
     ncl_name: VGTYP_P0_L1_{grid} # choosing one of the un-transformed values in the algorithm
     ticks: 0
     title: Hourly Wildfire Potential

--- a/adb_graphics/specs.py
+++ b/adb_graphics/specs.py
@@ -299,6 +299,16 @@ class VarSpec(abc.ABC):
         return np.concatenate((ncar, grays))
 
     @property
+    def rainbow11_colors(self) -> np.ndarray:
+
+        ''' Default color map for Hourly Wildfire Potential '''
+
+        grays = cm.get_cmap('Greys', 2)([0])
+        ncar = cm.get_cmap(self.vspec.get('cmap'), 128) \
+                          ([18, 20, 25, 50, 60, 70, 80, 85, 90, 100, 120])
+        return np.concatenate((grays, ncar))
+
+    @property
     def rainbow12_colors(self) -> np.ndarray:
 
         ''' Default color map for ACPCP, ACSNOD, HLCY, RH, and SNOD '''


### PR DESCRIPTION
Ravan had some requests in an email to me:

Can you make a few changes in the colorbars?
- Let's show HWP>10 only. So we can remove the dark blue color from the colorbar.
- For near-surface dust let's show >1 only. To use the same number of colors we can add 75 to the colorbar. 
- For ver.int.dust let's show >1 only. Let's set the maximum to 150, and change "100,200" to "75,110,150". 
Thus we don't need to show the decimal parts of the values in the colorbars for the dust plots. 

I've made these changes in this PR.
