### PR TITLE
Capability for users to create batch difference plots

### DIFF
--- a/adb_graphics/datahandler/gribdata.py
+++ b/adb_graphics/datahandler/gribdata.py
@@ -724,6 +724,8 @@ class fieldData(UPPData):
 
     @property
     def data(self):
+        ''' Sets the data property on the object for use when we need to update
+        the values associated with a given object -- helpful for differences.'''
         if not hasattr(self, '_data'):
             return self.values()
         return self._data

--- a/adb_graphics/datahandler/gribdata.py
+++ b/adb_graphics/datahandler/gribdata.py
@@ -722,6 +722,16 @@ class fieldData(UPPData):
 
         return self.vspec.get('unit', self.field.units)
 
+    @property
+    def data(self):
+        if not hasattr(self, '_data'):
+            return self.values()
+        return self._data
+
+    @data.setter
+    def data(self, value):
+        self._data = value
+
     def values(self, level=None, name=None, **kwargs):
 
         '''

--- a/adb_graphics/figure_builders.py
+++ b/adb_graphics/figure_builders.py
@@ -140,7 +140,7 @@ def parallel_maps(cla, fhr, ds, level, model, spec, variable, workdir,
                        '2nd set of files. Skipping.'))
                 return
 
-            field.values = field.values() - field2.values()
+            field.data = field.values() - field2.values()
 
 
         map_fields = maps.MapFields(

--- a/adb_graphics/figure_builders.py
+++ b/adb_graphics/figure_builders.py
@@ -52,9 +52,10 @@ def add_obs_panel(ax, model_name, obs_file, proj_info, short_name, tile):
     dm.draw(show=True)
 
 def parallel_maps(cla, fhr, ds, level, model, spec, variable, workdir,
-                  tile='full'):
+                  tile='full', ds2=None):
 
     # pylint: disable=too-many-arguments,too-many-locals
+    # pylint: disable=too-many-branches,too-many-statements
 
     '''
     Function that creates plan-view maps, either a single panel, or
@@ -82,8 +83,11 @@ def parallel_maps(cla, fhr, ds, level, model, spec, variable, workdir,
     last_panel = False
 
     # Declare the type of object depending on graphic type
-    map_class = maps.MultiPanelDataMap if cla.graphic_type == \
-        'enspanel' else maps.DataMap
+    map_classes = {
+        "enspanel": maps.MultiPanelDataMap,
+        "diff": maps.DiffMap,
+        }
+    map_class = map_classes.get(cla.graphic_type, maps.DataMap)
 
     for index, current_ax in enumerate(axes):
 
@@ -116,6 +120,27 @@ def parallel_maps(cla, fhr, ds, level, model, spec, variable, workdir,
         except errors.GribReadError:
             print(f'Cannot find grib2 variable for {variable} at {level}. Skipping.')
             return
+
+        if cla.graphic_type == "diff":
+
+            field2 = gribdata.fieldData(
+                ds=ds2,
+                fhr=fhr,
+                filetype=cla.file_type,
+                level=level,
+                member=mem,
+                model=model,
+                short_name=variable,
+                )
+
+            try:
+                field2.field
+            except errors.GribReadError:
+                print((f'Cannot find grib2 variable for {variable} at {level} in',
+                       '2nd set of files. Skipping.'))
+                return
+
+            field.values = field.values() - field2.values()
 
 
         map_fields = maps.MapFields(

--- a/adb_graphics/figures/maps.py
+++ b/adb_graphics/figures/maps.py
@@ -392,7 +392,7 @@ class DataMap():
         '''
 
         x, y = self._xy_mesh(field)
-        vals = field.values
+        vals = field.data
 
         # For global lat-lon models, make 2D arrays for x and y
         # Shift the map and data if needed
@@ -423,7 +423,7 @@ class DataMap():
         lats = self.map.airports[:, 0]
         lons = 360 + self.map.airports[:, 1]
         x, y = self.map.m(lons, lats)
-        data_values = self.field.values
+        data_values = self.field.data
         crnrs = copy.copy(self.map.corners)
         if crnrs[2] < 0:
             crnrs[2] = 360 + crnrs[2]
@@ -645,8 +645,8 @@ class DiffMap(DataMap):
     def _eq_contours(self):
         ''' Center the contours based on the data min/max '''
 
-        minval = np.amin(self.field.values)
-        maxval = np.amax(self.field.values)
+        minval = np.amin(self.field.data)
+        maxval = np.amax(self.field.data)
         if minval == maxval == 0:
             return np.array([-1, 0, 1])
         maxval = max(abs(minval), abs(maxval))

--- a/adb_graphics/figures/maps.py
+++ b/adb_graphics/figures/maps.py
@@ -392,7 +392,7 @@ class DataMap():
         '''
 
         x, y = self._xy_mesh(field)
-        vals = field.values()
+        vals = field.values
 
         # For global lat-lon models, make 2D arrays for x and y
         # Shift the map and data if needed
@@ -423,7 +423,7 @@ class DataMap():
         lats = self.map.airports[:, 0]
         lons = 360 + self.map.airports[:, 1]
         x, y = self.map.m(lons, lats)
-        data_values = self.field.values()
+        data_values = self.field.values
         crnrs = copy.copy(self.map.corners)
         if crnrs[2] < 0:
             crnrs[2] = 360 + crnrs[2]
@@ -601,6 +601,86 @@ class DataMap():
 
         adjust = 360 if np.any(lon < 0) else 0
         return self.map.m(adjust + lon, lat)
+
+class DiffMap(DataMap):
+    '''
+    Extends DataMap for handling difference plots, which need different titles,
+    and will not plot overlays and such.
+    '''
+
+    def _colorbar(self, cc, ax):
+
+        ''' Set the colorbar for a difference field. '''
+
+        plt.colorbar(
+            cc,
+            ax=ax,
+            orientation='horizontal',
+            pad=0.02,
+            shrink=1.0,
+            )
+
+    def _draw_panel(self, wind_barbs=False):
+
+        ''' Draw a map of the difference field. '''
+
+        ax = self.map.ax
+
+        # Draw a map and add the shaded field
+        self.map.draw()
+
+        # The number of levels (nlev) here, should be the same number as is used
+        # in the linspace call in self._eq_contours. 21 seems reasonable, but is
+        # arbitrary.
+        colors = self.field.centered_diff(cmap='Spectral_r', nlev=21)
+        cf = self._draw_field(ax=ax,
+                              colors=colors,
+                              extend='both',
+                              field=self.field,
+                              func=self.map.m.contourf,
+                              levels=self._eq_contours(),
+                              )
+        return cf
+
+    def _eq_contours(self):
+        ''' Center the contours based on the data min/max '''
+
+        minval = np.amin(self.field.values)
+        maxval = np.amax(self.field.values)
+        if minval == maxval == 0:
+            return np.array([-1, 0, 1])
+        maxval = max(abs(minval), abs(maxval))
+        return np.linspace(-maxval, maxval, 21)
+
+    def _title(self):
+        ''' Draw the title for a map. '''
+
+        f = self.field
+        atime = f.date_to_str(f.anl_dt)
+        vtime = f.date_to_str(f.valid_dt)
+
+        # Analysis time (top) and forecast hour with Valid Time (bottom) on the left
+        plt.title(f"{self.model_name}: {atime}\nFcst Hr: {f.fhr}, Valid Time {vtime}",
+                  alpha=None,
+                  fontsize=14,
+                  loc='left',
+                  )
+
+        level, lev_unit = f.numeric_level(index_match=False)
+        if f.vspec.get('print_units', True):
+            units = f'({f.units}, shaded)'
+        else:
+            units = f''
+
+        # Title or Atmospheric level and unit in the high center
+        if f.vspec.get('title'):
+            title = f"Diff: {f.vspec.get('title')} {units}"
+        else:
+            level = level if not isinstance(level, list) else level[0]
+            title = f'Diff: {level} {lev_unit} {f.field.long_name} {units}'
+        plt.title(f"{title}", position=(0.5, 1.08), fontsize=18)
+
+
 
 class MultiPanelDataMap(DataMap):
     '''

--- a/adb_graphics/specs.py
+++ b/adb_graphics/specs.py
@@ -26,15 +26,19 @@ class VarSpec(abc.ABC):
         with open(config, 'r') as cfg:
             self.yml = yaml.load(cfg, Loader=yaml.Loader)
 
-    def centered_diff(self):
+    def centered_diff(self, cmap=None, nlev=None):
 
         ''' Returns the colors specified by levels and cmap in default spec, but
         with white center. '''
 
-        clevs = self.vspec.get('clevs')
-        nlev = len(clevs) + 1
+        if nlev is None:
+            clevs = self.vspec.get('clevs')
+            nlev = len(clevs) + 1
 
-        colors = cm.get_cmap(self.vspec.get('cmap'), nlev)(range(nlev))
+        if cmap is None:
+            cmap = self.vspec.get('cmap')
+
+        colors = cm.get_cmap(cmap, nlev)(range(nlev))
         mid = nlev // 2
 
         colors[mid] = [1, 1, 1, 1]

--- a/image_lists/rrfs_subset.yml
+++ b/image_lists/rrfs_subset.yml
@@ -1,97 +1,97 @@
 hourly:
   model: rrfs
   variables:
-    1hsnw:
-      - sfc
-    1ref:
-      - 1000m
-    acfrozr:
-      - sfc
-    acfrzr:
-      - sfc
-    acpcp:
-      - sfc
-    acsnod:
-      - sfc
-    acsnw:
-      - sfc
-    cape:
-      - mu
-      - mul
-      - mx90mb
-      - sfc
-    ceil:
-      - ua
-    ceilexp:
-      - ua
-    ceilexp2:
-      - ua
-    cin:
-      - sfc
-    cloudcover:
-      - bndylay
-      - high
-      - low
-      - mid
-      - total
-    cpofp:
-      - sfc
-    cref:
-      - sfc
-    ctop:
-      - ua
-    dewp:
-      - 2m
-    dust:
-      - int
-      - sfc
-    echotop:
-      - sfc
-    firewx:
-      - sfc
-    flru:
-      - sfc
-    G113bt:
-      - sat
-    G114bt:
-      - sat
-    G123bt:
-      - sat
-    G124bt:
-      - sat
-    gust:
-      - 10m
-    hail:
-      - max
-      - maxsfc
-    hailcast:
-      - maxsfc
-    hlcy:
-      - in25
-      - mn03
-      - mn25
-      - mx03
-      - mx25
-      - sr01
-      - sr03
-    hlcytot:
-      - mn03
-      - mn25
-      - mx03
-      - mx25
-    hpbl:
-      - sfc
-    lcl:
-      - sfc
-    lhtfl:
-      - sfc
-    li:
-      - best
-      - sfc
-    ltg3:
-      - sfc
-    mref:
-      - sfc
+    #    1hsnw:
+    #      - sfc
+    #    1ref:
+    #      - 1000m
+    #    acfrozr:
+    #      - sfc
+    #    acfrzr:
+    #      - sfc
+    #    acpcp:
+    #      - sfc
+    #    acsnod:
+    #      - sfc
+    #    acsnw:
+    #      - sfc
+    #    cape:
+    #      - mu
+    #      - mul
+    #      - mx90mb
+    #      - sfc
+    #    ceil:
+    #      - ua
+    #    ceilexp:
+    #      - ua
+    #    ceilexp2:
+    #      - ua
+    #    cin:
+    #      - sfc
+    #    cloudcover:
+    #      - bndylay
+    #      - high
+    #      - low
+    #      - mid
+    #      - total
+    #    cpofp:
+    #      - sfc
+    #    cref:
+    #      - sfc
+    #    ctop:
+    #      - ua
+    #    dewp:
+    #      - 2m
+    #    dust:
+    #      - int
+    #      - sfc
+    #    echotop:
+    #      - sfc
+    #    firewx:
+    #      - sfc
+    #    flru:
+    #      - sfc
+    #    G113bt:
+    #      - sat
+    #    G114bt:
+    #      - sat
+    #    G123bt:
+    #      - sat
+    #    G124bt:
+    #      - sat
+    #    gust:
+    #      - 10m
+    #    hail:
+    #      - max
+    #      - maxsfc
+    #    hailcast:
+    #      - maxsfc
+    #    hlcy:
+    #      - in25
+    #      - mn03
+    #      - mn25
+    #      - mx03
+    #      - mx25
+    #      - sr01
+    #      - sr03
+    #    hlcytot:
+    #      - mn03
+    #      - mn25
+    #      - mx03
+    #      - mx25
+    #    hpbl:
+    #      - sfc
+    #    lcl:
+    #      - sfc
+    #    lhtfl:
+    #      - sfc
+    #    li:
+    #      - best
+    #      - sfc
+    #    ltg3:
+    #      - sfc
+    #    mref:
+    #      - sfc
     pres:
       - msl
       - sfc
@@ -109,34 +109,33 @@ hourly:
       - 850mb
       - mean
       - pw
-    rvil:
-      - sfc
-    shear:
-      - 01km
-      - 06km
-    shtfl:
-      - sfc
-    snod:
-      - sfc
-    soilm:
-      - sfc
-    soilt: &soilt_levs
-      - 0cm
-      - 1cm
-      - 4cm
-      - 10cm
-      - 30cm
-      - 60cm
-      - 1m
-      - 1.6m
-      - 3m
-    soilw: *soilt_levs
-    solar:
-      - sfc
-    ssrun:
-      - sfc
+    #    rvil:
+    #      - sfc
+    #    shear:
+    #      - 01km
+    #      - 06km
+    #    shtfl:
+    #      - sfc
+    #    snod:
+    #      - sfc
+    #    soilm:
+    #      - sfc
+    #    soilt: &soilt_levs
+    #      - 0cm
+    #      - 1cm
+    #      - 4cm
+    #      - 10cm
+    #      - 30cm
+    #      - 60cm
+    #      - 1m
+    #      - 1.6m
+    #      - 3m
+    #    soilw: *soilt_levs
+    #    solar:
+    #      - sfc
+    #    ssrun:
+    #      - sfc
     temp:
-      - 2ds
       - 2m
       - 500mb
       - 700mb
@@ -145,40 +144,40 @@ hourly:
       - sfc
     totp:
       - sfc
-    trc1:
-      - int
-      - sfc
-    ulwrf:
-      - sfc
-      - top
-    uswrf:
-      - sfc
-      - top
-    vbdsf:
-      - sfc
-    vddsf:
-      - sfc
-    vig:
-      - sfc
-    vil:
-      - sfc
-    vis:
-      - sfc
-    vort:
-      - 500mb
-    vvel:
-      - 700mb
-      - mean
-    vvort:
-      - mx01
-      - mx02
-    weasd:
-      - sfc
-    wspeed:
-      - 10m
-      - 80m
-      - 250mb
-      - 850mb
-      - max
-      - mdn
-      - mup
+    #    trc1:
+    #      - int
+    #      - sfc
+    #    ulwrf:
+    #      - sfc
+    #      - top
+    #    uswrf:
+    #      - sfc
+    #      - top
+    #    vbdsf:
+    #      - sfc
+    #    vddsf:
+    #      - sfc
+    #    vig:
+    #      - sfc
+    #    vil:
+    #      - sfc
+    #    vis:
+    #      - sfc
+    #    vort:
+    #      - 500mb
+    #    vvel:
+    #      - 700mb
+    #      - mean
+    #    vvort:
+    #      - mx01
+    #      - mx02
+    #    weasd:
+    #      - sfc
+    #    wspeed:
+    #      - 10m
+    #      - 80m
+    #      - 250mb
+    #      - 850mb
+    #      - max
+    #      - mdn
+    #      - mup

--- a/image_lists/rrfs_subset.yml
+++ b/image_lists/rrfs_subset.yml
@@ -1,97 +1,97 @@
 hourly:
   model: rrfs
   variables:
-    #    1hsnw:
-    #      - sfc
-    #    1ref:
-    #      - 1000m
-    #    acfrozr:
-    #      - sfc
-    #    acfrzr:
-    #      - sfc
-    #    acpcp:
-    #      - sfc
-    #    acsnod:
-    #      - sfc
-    #    acsnw:
-    #      - sfc
-    #    cape:
-    #      - mu
-    #      - mul
-    #      - mx90mb
-    #      - sfc
-    #    ceil:
-    #      - ua
-    #    ceilexp:
-    #      - ua
-    #    ceilexp2:
-    #      - ua
-    #    cin:
-    #      - sfc
-    #    cloudcover:
-    #      - bndylay
-    #      - high
-    #      - low
-    #      - mid
-    #      - total
-    #    cpofp:
-    #      - sfc
-    #    cref:
-    #      - sfc
-    #    ctop:
-    #      - ua
-    #    dewp:
-    #      - 2m
-    #    dust:
-    #      - int
-    #      - sfc
-    #    echotop:
-    #      - sfc
-    #    firewx:
-    #      - sfc
-    #    flru:
-    #      - sfc
-    #    G113bt:
-    #      - sat
-    #    G114bt:
-    #      - sat
-    #    G123bt:
-    #      - sat
-    #    G124bt:
-    #      - sat
-    #    gust:
-    #      - 10m
-    #    hail:
-    #      - max
-    #      - maxsfc
-    #    hailcast:
-    #      - maxsfc
-    #    hlcy:
-    #      - in25
-    #      - mn03
-    #      - mn25
-    #      - mx03
-    #      - mx25
-    #      - sr01
-    #      - sr03
-    #    hlcytot:
-    #      - mn03
-    #      - mn25
-    #      - mx03
-    #      - mx25
-    #    hpbl:
-    #      - sfc
-    #    lcl:
-    #      - sfc
-    #    lhtfl:
-    #      - sfc
-    #    li:
-    #      - best
-    #      - sfc
-    #    ltg3:
-    #      - sfc
-    #    mref:
-    #      - sfc
+    1hsnw:
+      - sfc
+    1ref:
+      - 1000m
+    acfrozr:
+      - sfc
+    acfrzr:
+      - sfc
+    acpcp:
+      - sfc
+    acsnod:
+      - sfc
+    acsnw:
+      - sfc
+    cape:
+      - mu
+      - mul
+      - mx90mb
+      - sfc
+    ceil:
+      - ua
+    ceilexp:
+      - ua
+    ceilexp2:
+      - ua
+    cin:
+      - sfc
+    cloudcover:
+      - bndylay
+      - high
+      - low
+      - mid
+      - total
+    cpofp:
+      - sfc
+    cref:
+      - sfc
+    ctop:
+      - ua
+    dewp:
+      - 2m
+    dust:
+      - int
+      - sfc
+    echotop:
+      - sfc
+    firewx:
+      - sfc
+    flru:
+      - sfc
+    G113bt:
+      - sat
+    G114bt:
+      - sat
+    G123bt:
+      - sat
+    G124bt:
+      - sat
+    gust:
+      - 10m
+    hail:
+      - max
+      - maxsfc
+    hailcast:
+      - maxsfc
+    hlcy:
+      - in25
+      - mn03
+      - mn25
+      - mx03
+      - mx25
+      - sr01
+      - sr03
+    hlcytot:
+      - mn03
+      - mn25
+      - mx03
+      - mx25
+    hpbl:
+      - sfc
+    lcl:
+      - sfc
+    lhtfl:
+      - sfc
+    li:
+      - best
+      - sfc
+    ltg3:
+      - sfc
+    mref:
+      - sfc
     pres:
       - msl
       - sfc
@@ -109,33 +109,34 @@ hourly:
       - 850mb
       - mean
       - pw
-    #    rvil:
-    #      - sfc
-    #    shear:
-    #      - 01km
-    #      - 06km
-    #    shtfl:
-    #      - sfc
-    #    snod:
-    #      - sfc
-    #    soilm:
-    #      - sfc
-    #    soilt: &soilt_levs
-    #      - 0cm
-    #      - 1cm
-    #      - 4cm
-    #      - 10cm
-    #      - 30cm
-    #      - 60cm
-    #      - 1m
-    #      - 1.6m
-    #      - 3m
-    #    soilw: *soilt_levs
-    #    solar:
-    #      - sfc
-    #    ssrun:
-    #      - sfc
+    rvil:
+      - sfc
+    shear:
+      - 01km
+      - 06km
+    shtfl:
+      - sfc
+    snod:
+      - sfc
+    soilm:
+      - sfc
+    soilt: &soilt_levs
+      - 0cm
+      - 1cm
+      - 4cm
+      - 10cm
+      - 30cm
+      - 60cm
+      - 1m
+      - 1.6m
+      - 3m
+    soilw: *soilt_levs
+    solar:
+      - sfc
+    ssrun:
+      - sfc
     temp:
+      - 2ds
       - 2m
       - 500mb
       - 700mb
@@ -144,40 +145,40 @@ hourly:
       - sfc
     totp:
       - sfc
-    #    trc1:
-    #      - int
-    #      - sfc
-    #    ulwrf:
-    #      - sfc
-    #      - top
-    #    uswrf:
-    #      - sfc
-    #      - top
-    #    vbdsf:
-    #      - sfc
-    #    vddsf:
-    #      - sfc
-    #    vig:
-    #      - sfc
-    #    vil:
-    #      - sfc
-    #    vis:
-    #      - sfc
-    #    vort:
-    #      - 500mb
-    #    vvel:
-    #      - 700mb
-    #      - mean
-    #    vvort:
-    #      - mx01
-    #      - mx02
-    #    weasd:
-    #      - sfc
-    #    wspeed:
-    #      - 10m
-    #      - 80m
-    #      - 250mb
-    #      - 850mb
-    #      - max
-    #      - mdn
-    #      - mup
+    trc1:
+      - int
+      - sfc
+    ulwrf:
+      - sfc
+      - top
+    uswrf:
+      - sfc
+      - top
+    vbdsf:
+      - sfc
+    vddsf:
+      - sfc
+    vig:
+      - sfc
+    vil:
+      - sfc
+    vis:
+      - sfc
+    vort:
+      - 500mb
+    vvel:
+      - 700mb
+      - mean
+    vvort:
+      - mx01
+      - mx02
+    weasd:
+      - sfc
+    wspeed:
+      - 10m
+      - 80m
+      - 250mb
+      - 850mb
+      - max
+      - mdn
+      - mup


### PR DESCRIPTION
Users now have the option to create a "diff" plot using `create_graphics.py`. It will accept two directories with two options 
 for file name templates, and will create all the difference maps for variables specified in the image list. All other behaviors are similar to regular map plotting (forecast hours, regions, etc.).
 
 There are a few things it won't do out of the box:

- Plot differences from different models. HRRR and RRFS, for example.
- Plot graphics accumulated variables. It will plot the variables labeled as accumulated in UPP, though.
- Have a uniform color scale across variables. Each plot will assess the min/max values of the data field and use those numbers to set the value range.
- Use different color maps. That's hard coded.

Here is an example plot:
![image](https://user-images.githubusercontent.com/56881914/204611575-1383ca4c-e7c5-4603-bde4-3254f168fcc6.png)



I'll add some additional comments to the code after the PR is opened.
