### PR TITLE
adding and fixing experimental ceiling versions for RRFS/RTMA.

### DIFF
--- a/adb_graphics/default_specs.yml
+++ b/adb_graphics/default_specs.yml
@@ -334,7 +334,7 @@ ceil: # Ceiling
 ceilexp: # Ceiling - experimental
   ua:
     <<: *ceil
-    ncl_name: CEIL_P0_{grid}
+    ncl_name: CEIL_P0_L215_{grid}
     title: Ceiling (exp)
 ceilexp2: # Ceiling - experimental no.2
   ua:

--- a/image_lists/rtma.yml
+++ b/image_lists/rtma.yml
@@ -16,8 +16,8 @@ hourly:
       - ua
     ceilexp:
       - ua
-#    ceilexp2:
-#      - ua
+    ceilexp2:
+      - ua
     cin:
       - sfc
     cloudcover:


### PR DESCRIPTION
Adjustments to plot three different ceiling versions for both RRFS and RTMA.  "ceilexp" had an incorrect ncl_name, and "ceilexp2" had been commented out for RTMA.  These changes were tested as a hot fix and appear to be working correctly.

passed pylint and pytest.

no before/after plots needed.