### PR TITLE
initial changes for SLW colors to match NCL version.

### DIFF
--- a/adb_graphics/default_specs.yml
+++ b/adb_graphics/default_specs.yml
@@ -1062,9 +1062,9 @@ shtfl: # Sensible Heat Net Flux
 slw: # Supercooled Liquid Water
   sfc:
     clevs: [0.05, 0.1, 0.2, .3, .4, .5, .75, 1., 1.25, 1.5, 2., 3., 4., 5., 6.]
-    cmap: NWSReflectivity
-    colors: cref_colors
-    ncl_name: VIL_P0_L10_{grid}
+    cmap: gist_ncar
+    colors: slw_colors
+    ncl_name: TMP_P0_L1_{grid}
     ticks: 0
     title: Supercooled Liquid Water
     transform: supercooled_liquid_water

--- a/adb_graphics/specs.py
+++ b/adb_graphics/specs.py
@@ -316,6 +316,17 @@ class VarSpec(abc.ABC):
         return ctable
 
     @property
+    def slw_colors(self) -> np.ndarray:
+
+        ''' Default color map for Max Vertically Integrated Graupel '''
+
+        white = cm.get_cmap('Greys', 3)([0])
+        purples = cm.get_cmap('nipy_spectral', 30)([3, 1])
+        ncar = cm.get_cmap(self.vspec.get('cmap'), 15) \
+                          ([2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14])
+        return np.concatenate((white, purples, ncar))
+
+    @property
     def smoke_colors(self) -> np.ndarray:
 
         ''' Default color map for smoke plots. '''


### PR DESCRIPTION
This changes the color table for supercooled liquid water (SLW) to match the old NCL colors, which seemed to be a preference for Steve W.  It also fixes an issue with a placeholder field for SLW in default_specs which was in HRRR but not in RRFS.

passed pylint and pytest.

sample of NCL, old python, and new python colors below.
![image](https://user-images.githubusercontent.com/56739562/206292427-14d27e8a-c9ab-44fc-9400-d9b5dfc9910e.png)
![image](https://user-images.githubusercontent.com/56739562/206292458-9f8fa5b0-41cf-4be5-8078-23da58c58cff.png)
![image](https://user-images.githubusercontent.com/56739562/206292523-e1995202-6147-4b5e-b58c-65db8c64d31c.png)
