### PR TITLE
fix ncl_name for ice pellets (CICEP)

### DIFF
--- a/adb_graphics/default_specs.yml
+++ b/adb_graphics/default_specs.yml
@@ -349,7 +349,7 @@ cfrzr: # Categorical Freezing Rain
     ncl_name: CFRZR_P0_L1_{grid}
 cicep: # Categorical Ice Pellets
   sfc:
-    ncl_name: CFRZR_P0_L1_{grid}
+    ncl_name: CICEP_P0_L1_{grid}
 cin: # Surface Convective Inhibition
   mu:
     clevs: [-300, -200, -150, -100, -75, -50, -40, -30, -20, -10, -1]


### PR DESCRIPTION
Trevor Alcott notices an issue with the precip type plots (ptyp) for the sleet (ice pellets), CICEP.  It turned out that the wrong ncl_name was being used in default_specs.yml.  That's been corrected.

Passed pylint and pytest.
samples of Trevor's plot, old pygraf plot and new pygraf plot below.
![image](https://user-images.githubusercontent.com/56739562/210668787-fc0f2f07-03eb-44bd-bd79-167902ad23c4.png)
<img width="297" alt="Screen Shot 2023-01-04 at 4 15 04 PM" src="https://user-images.githubusercontent.com/56739562/210668821-b81fdac8-4afc-4d5a-a05b-1ddb0e54a805.png">


