### PR TITLE
Run max

### DIFF
--- a/adb_graphics/datahandler/gribdata.py
+++ b/adb_graphics/datahandler/gribdata.py
@@ -671,6 +671,22 @@ class fieldData(UPPData):
 
         return vals
 
+    def run_max(self, values, **kwargs):
+
+        ''' Finds the max hourly value over all the forecast lead times available. '''
+
+        # pylint: disable=unused-argument,no-self-use
+
+        return values.max(dim='fcst_hr')
+
+    def run_min(self, values, **kwargs):
+
+        ''' Finds the min (largest negative) hourly value over all the forecast lead times available. '''
+
+        # pylint: disable=unused-argument,no-self-use
+
+        return values.min(dim='fcst_hr')
+
     def run_total(self, values, **kwargs):
 
         ''' Sums over all the forecast lead times available. '''

--- a/adb_graphics/datahandler/gribdata.py
+++ b/adb_graphics/datahandler/gribdata.py
@@ -681,7 +681,7 @@ class fieldData(UPPData):
 
     def run_min(self, values, **kwargs):
 
-        ''' Finds the min (largest negative) hourly value over all the forecast lead times available. '''
+        ''' Finds the min hourly value over all the forecast lead times available. '''
 
         # pylint: disable=unused-argument,no-self-use
 

--- a/adb_graphics/default_specs.yml
+++ b/adb_graphics/default_specs.yml
@@ -719,42 +719,42 @@ hlcytot:
     <<: *hlcy_mn
     accumulate: True
     title: Run Total 0-2km Min Updraft Helicity
-    transform: run_total
+    transform: run_min
   mn03:
     <<: *hlcy_mn03
     accumulate: True
     title: Run Total 0-3km Min Updraft Helicity
-    transform: run_total
+    transform: run_min
   mn16:
     <<: *hlcy_mn16
     accumulate: True
     title: Run Total 1-6km Min Updraft Helicity
-    transform: run_total
+    transform: run_min
   mn25:
     <<: *hlcy_mn25
     accumulate: True
     title: Run Total 2-5km Min Updraft Helicity
-    transform: run_total
+    transform: run_min
   mx02:
     <<: *hlcy_mx02
     accumulate: True
     title: Run Total 0-2km Max Updraft Helicity
-    transform: run_total
+    transform: run_max
   mx03:
     <<: *hlcy_mx03
     accumulate: True
     title: Run Total 0-3km Max Updraft Helicity
-    transform: run_total
+    transform: run_max
   mx16:
     <<: *hlcy_mx16
     accumulate: True
     title: Run Total 1-6km Max Updraft Helicity
-    transform: run_total
+    transform: run_max
   mx25:
     <<: *hlcy_mx25
     accumulate: True
     title: Run Total 2-5km Max Updraft Helicity
-    transform: run_total
+    transform: run_max
 hpbl: # Height of Planetary Boundary Layer
   sfc: 
     clevs: [25, 50, 100, 200, 300, 500, 750, 1000, 1500, 2000, 2500, 3000, 4000, 5000]


### PR DESCRIPTION
This change adds two new methods, run_max and run_min, analogous to run_total, for use with run-total helicity.  Helicity runs should show the maximum/minimum over the course of the forecast run, rather than the summed amounts.

Passed pylint and pytest.

Examples below.

Before and after, 0-3 km min helicity, EastCO domain:
![image](https://user-images.githubusercontent.com/56739562/218525291-f12a3ef1-dadf-45ac-aa83-21b18cfab49e.png)
![image](https://user-images.githubusercontent.com/56739562/218525336-d84fc15b-7463-4c97-871f-18911a386010.png)


Before and after, 0-3 km max helicity, EastCO domain:
![image](https://user-images.githubusercontent.com/56739562/218525387-6d33248f-a1a9-4d73-937b-eece358aada8.png)
![image](https://user-images.githubusercontent.com/56739562/218525417-c24f46eb-2d93-49f8-a53b-34765d1999e7.png)

