### PR TITLE
skewT required arguments

### DIFF
--- a/create_graphics.py
+++ b/create_graphics.py
@@ -708,6 +708,13 @@ if __name__ == '__main__':
                        "fields is not supported!")
             print(warning)
 
+    # Make sure both required arguments (--max_plev, --sites) are provided when doing skewTs
+    if CLARGS.graphic_type == 'skewts':
+        if not CLARGS.max_plev:
+            argparse.ArgumentParser.exit(0, "Must specify maximum pressure level (--max_plev) when creating skewTs")
+        if not CLARGS.sites:
+            argparse.ArgumentParser.exit(0, "Must specify sites (--sites) when creating skewTs")
+
     print(f"Running script for {CLARGS.graphic_type} with args: ",
           f"{LOG_BREAK}")
 

--- a/create_graphics.py
+++ b/create_graphics.py
@@ -711,7 +711,8 @@ if __name__ == '__main__':
     # Make sure both required arguments (--max_plev, --sites) are provided when doing skewTs
     if CLARGS.graphic_type == 'skewts':
         if not CLARGS.max_plev:
-            argparse.ArgumentParser.exit(0, "Must specify maximum pressure level (--max_plev) when creating skewTs")
+            argparse.ArgumentParser.exit(0, "Must specify maximum pressure level \
+                (--max_plev) when creating skewTs")
         if not CLARGS.sites:
             argparse.ArgumentParser.exit(0, "Must specify sites (--sites) when creating skewTs")
 


### PR DESCRIPTION
This change adds a check that is specific to skewT diagrams.
If --max_plev or --sites arguments are missing, parser throws an error message indicating which required argument is missing and exits the application without dumping further exception messages to user.