### PR TITLE
Changes to make wind contour levels above 250mb to be the same as 250mb.

### DIFF
--- a/adb_graphics/default_specs.yml
+++ b/adb_graphics/default_specs.yml
@@ -1702,15 +1702,16 @@ wspeed: # Wind Speed
         field2: VGRD_P0_L103_{grid}
     unit: kt
     wind: True
-  5mb: &shaded_ua_wspeed
-    clevs: !!python/object/apply:numpy.arange [5, 95, 5]
+  5mb: &ua_wspeed_high
+    clevs: [20, 40, 60, 70, 80, 90, 100, 110, 120, 140, 160, 180, 200]
     cmap: gist_ncar
-    colors: wind_colors
+    colors: wind_colors_high
     contours:
       gh:
         colors: white
         linewidths: 1.2
     ncl_name: UGRD_P0_L100_{grid}
+    ticks: 0
     title: 5mb Wind
     transform:
       funcs: [vector_magnitude, conversions.ms_to_kt]
@@ -1719,26 +1720,14 @@ wspeed: # Wind Speed
     unit: kt
     wind: True
   10mb:
-    <<: *shaded_ua_wspeed
+    <<: *ua_wspeed_high
     title: 10mb Wind
   20mb:
-    <<: *shaded_ua_wspeed
+    <<: *ua_wspeed_high
     title: 20mb Wind
   250mb:
-    <<: *ua_wspeed
-    clevs: [20, 40, 60, 70, 80, 90, 100, 110, 120, 140, 160, 180, 200]
-    colors: wind_colors_high
-    contours:
-      gh:
-        colors: white
-        linewidths: 1.2
-    ncl_name: UGRD_P0_L100_{grid}
-    ticks: 0
+    <<: *ua_wspeed_high
     title: 250mb Wind
-    transform:
-      funcs: [vector_magnitude, conversions.ms_to_kt]
-      kwargs: 
-        field2: VGRD_P0_L100_{grid}
   80m:
     <<: *ua_wspeed
     title: 80m Wind


### PR DESCRIPTION
Stan requested that wind levels above 250mb have the same contour levels as 250mb.
Tested with global data (HRRR and probably RRFS don't have these higher levels).
Passed pylint and pytest.

![image](https://user-images.githubusercontent.com/58485074/219461478-2fe57497-8987-49b4-ad5f-37359afd9e55.png)
![image](https://user-images.githubusercontent.com/58485074/219461551-8d44a46a-f954-4f69-854b-f069d06c93e9.png)
![image](https://user-images.githubusercontent.com/58485074/219461606-b615c9e9-3e21-4384-b1d4-5417ef69979a.png)
![image](https://user-images.githubusercontent.com/58485074/219461653-47b7b58d-f69c-447d-8259-ea080708d25c.png)
