### PR TITLE
VISBSN plots

### DIFF
--- a/adb_graphics/default_specs.yml
+++ b/adb_graphics/default_specs.yml
@@ -1624,7 +1624,7 @@ vil: # Vertically Integrated Liquid
     ncl_name: VAR_0_16_201_P0_L10_{grid}
     title: Vertically Integrated Liquid
 vis: # Visibility
-  sfc:
+  sfc: &vis
     # see the description provided in adb_graphics/utils.py, for the join_ranges method.
     clevs: !join_ranges [[0, 10, 0.1], [10, 51, 1.0]]
     cmap: gist_ncar
@@ -1634,6 +1634,11 @@ vis: # Visibility
     title: Sfc Visibility
     transform: conversions.m_to_mi
     unit: mi
+visbsn: # Visibility incl. blowing snow
+  sfc:
+    <<: *vis
+    ncl_name: VAR_0_19_35_P0_L1_{grid}
+    title: Sfc Visibility incl. blowing snow (exp)
 vort: # Absolute vorticity
   500mb:
     clevs: !!python/object/apply:numpy.arange [6, 29, 2]

--- a/image_lists/rrfs_subset.yml
+++ b/image_lists/rrfs_subset.yml
@@ -166,6 +166,8 @@ hourly:
       - sfc
     vis:
       - sfc
+    visbsn:
+      - sfc
     vort:
       - 500mb
     vvel:


### PR DESCRIPTION
From Eric:
We just started outputting an additional visibility variable which includes the effect of blowing snow on the surface visibility. It's labeled as VISBSN, but with wgrib2 it shows up like this:
44:41424492:vt=2023021621:surface:3 hour fcst:var discipline=0 master_table=2 parmcat=19 parm=35:
Would it be possible to get graphics of this added to the web? We could just put in a new row under the existing visibility, labeled something like "visibility incl. blowing snow (experimental)". Note that it will only show up for RRFS-B, not HRRR or any other models. It would be good if we could do some evaluations of the effect of blowing snow, while we still have some winter remaining.

Changes to default_specs and image_lists/rrfs_subset to add this field.  Eric has a UPP fix in to allow the plots to be generated now.  Brian is adding a place on the RRFS_B Web page for the new field.

passed pylint and pytest.

Sample vis and visbsn plots below.
![image](https://user-images.githubusercontent.com/56739562/220705907-92467798-2fed-4c74-b8ad-6b44a7230877.png)
![image](https://user-images.githubusercontent.com/56739562/220705945-4e2300b6-5faf-4c6f-a394-eff13bf7f1a8.png)
