### PR TITLE
update high end of Tsfc color scale in specs.py

### DIFF
--- a/adb_graphics/specs.py
+++ b/adb_graphics/specs.py
@@ -443,7 +443,7 @@ class VarSpec(abc.ABC):
         temp4 = cm.get_cmap('RdPu_r', 8)(range(0, 8))
         temp5 = cm.get_cmap('BuPu', 5)(range(0, 4))
         temp6 = cm.get_cmap('RdYlBu_r', 10)(range(1, 10))
-        temp7 = cm.get_cmap('RdYlGn', 10)(range(0, 10))
+        temp7 = cm.get_cmap('BrBG', 20)(range(0, 10))
 
         return np.concatenate((temp1, temp2, temp3, temp4, temp5, temp6, temp7))
 


### PR DESCRIPTION
From Tanya:
Brian and Craig, will it be possible to change the color table on the temperature plots towards the right end when T > 90 F on the right plot and T>314K on the left plot. The current color table is confusing because it is impossible to say if temperature in the very southern part of Texas on the border with Mexico is 100F or 72F. Thank you!

![image](https://user-images.githubusercontent.com/56739562/221052302-36c3893b-3cd4-4a76-b1ad-acd89dab533c.png)

I changed the colors at the top end to a brown scale.  Waiting for Tanya to make sure it satisfies the need.  Sample before/after below.

Passed pylint and pytest.

![colors](https://user-images.githubusercontent.com/56739562/221053225-05e84764-17a1-4e38-8a7c-7e55f90accdb.jpg)
