### PR TITLE
Correcting FRZR problem for RRFS.

### DIFF
--- a/adb_graphics/datahandler/gribfile.py
+++ b/adb_graphics/datahandler/gribfile.py
@@ -106,6 +106,7 @@ class GribFiles():
                     'APCP',
                     'CDLYR',
                     'FROZR',
+                    'FRZR',
                     'LRGHR',
                     'TCDC',
                     'WEASD',


### PR DESCRIPTION
This was a hot fix that was put in place because the FRZR variable needed to be renamed at later hours for RRFS.  This was tested with RRFS_A, RRFS_B, and HRRR.