### PR TITLE
add run total maximum wind using hourly wind max

### DIFF
--- a/adb_graphics/default_specs.yml
+++ b/adb_graphics/default_specs.yml
@@ -1693,6 +1693,17 @@ weasd: # Water equivalent of accumulated snow depth
     title: Snow Water Equivalent
     transform: conversions.kgm2_to_in
     unit: in
+windmax:
+  10m:
+    accumulate: True
+    clevs: !!python/object/apply:numpy.arange [5, 95, 5]
+    cmap: gist_ncar
+    colors: wind_colors
+    ncl_name: WIND_P8_L103_{grid}_max1h
+    ticks: 5
+    title: 10m Wind Hourly Max
+    transform: [conversions.ms_to_kt, run_max]
+    unit: kt
 wspeed: # Wind Speed
   10m: &ua_wspeed
     clevs: !!python/object/apply:numpy.arange [5, 95, 5]


### PR DESCRIPTION
This PR is to add an option to plot the run total maximum wind plots.  I use the hourly max wind field in RRFS_B grib2 files, WIND_P8_L103_{grid}_max1h, so it doesn't need to merge U and V components, which seemed to confuse the run_max calculation.

Sample plots of wind and gust potential for 12h forecast, single-hr and run-total, below.

passed pylint and pytest.

[wind_max.pptx](https://github.com/NOAA-GSL/pygraf/files/10864587/wind_max.pptx)
