### PR TITLE
Additions for fine and coarse dust.

### DIFF
--- a/adb_graphics/default_specs.yml
+++ b/adb_graphics/default_specs.yml
@@ -409,6 +409,26 @@ clwmr: # Cloud water Mixing Ratio
     ncl_name: 
       nat: CLWMR_P0_L105_{grid}
       prs: CLWMR_P0_L100_{grid}
+coarsedust:
+  int: &coldust
+    clevs: [1, 2, 3, 4, 6, 8, 10, 15, 20, 30, 50, 75, 110, 150]
+    colors: smoke_colors
+    ncl_name: COLMD_P48_L200_{grid}_A62001_1
+    plot_airports: False
+    ticks: 0
+    title: Vertically Integrated Coarse Dust
+    transform: conversions.to_micro
+    unit: $mg/m^2$
+  sfc: &sfcdust
+    clevs: [1, 2, 3, 4, 6, 8, 10, 12, 15, 20, 30, 50, 75, 100]
+    colors: smoke_colors
+    ncl_name: MASSDEN_P48_L103_{grid}_A62001_1
+    plot_airports: False
+    title: Near-Surface Coarse Dust
+    transform: conversions.to_micrograms_per_m3
+    ticks: 0
+    unit: $\mu g/m^3$
+    wind: 10m
 cpofp: # Frozen Precipitation Percentage
   sfc:
     clevs: [-0.1, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100]
@@ -458,26 +478,15 @@ dewp: # Dew point temperature
     transform: conversions.k_to_f
     unit: F
     wind: 10m
-dust:
+finedust:
   int:
-    clevs: [1, 2, 3, 4, 6, 8, 10, 15, 20, 30, 50, 75, 110, 150]
-    colors: smoke_colors
+    <<: *coldust
     ncl_name: COLMD_P48_L200_{grid}_A62001
-    plot_airports: False
-    ticks: 0
-    title: Vertically Integrated Dust
-    transform: conversions.to_micro
-    unit: $mg/m^2$
+    title: Vertically Integrated Fine Dust
   sfc:
-    clevs: [1, 2, 3, 4, 6, 8, 10, 12, 15, 20, 30, 50, 75, 100]
-    colors: smoke_colors
+    <<: *sfcdust
     ncl_name: MASSDEN_P48_L103_{grid}_A62001
-    plot_airports: False
-    title: Near-Surface Dust
-    transform: conversions.to_micrograms_per_m3
-    ticks: 0
-    unit: $\mu g/m^3$
-    wind: 10m
+    title: Near-Surface Fine Dust
 echotop: # Echo Top
   sfc:
     clevs: !!python/object/apply:numpy.arange [4, 50, 3]

--- a/image_lists/rrfs_subset.yml
+++ b/image_lists/rrfs_subset.yml
@@ -34,6 +34,9 @@ hourly:
       - low
       - mid
       - total
+    coarsedust:
+      - int
+      - sfc
     cpofp:
       - sfc
     cref:
@@ -42,12 +45,12 @@ hourly:
       - ua
     dewp:
       - 2m
-    dust:
-      - int
-      - sfc
     echotop:
       - sfc
     emissions:
+      - sfc
+    finedust:
+      - int
       - sfc
     firewx:
       - sfc


### PR DESCRIPTION
For RRFS, the dust variable has been split into two parts, fine and coarse.  This has been accommodated in the default_specs.yml and rrfs_subset.yml.  Examples follow:

![image](https://user-images.githubusercontent.com/58485074/225705574-1e8300da-0620-4e71-8fde-43134b2e964d.png)
![image](https://user-images.githubusercontent.com/58485074/225705634-86df007e-1b1b-4415-8f87-7f72a9e3b45e.png)
![image](https://user-images.githubusercontent.com/58485074/225705712-ff7bbf07-f64b-44d3-9e1d-50a6fa9577e4.png)
![image](https://user-images.githubusercontent.com/58485074/225705774-f0ab8543-7768-442a-9537-f7d714b8ec06.png)
