### PR TITLE
Global acc var fix

### DIFF
--- a/adb_graphics/datahandler/gribfile.py
+++ b/adb_graphics/datahandler/gribfile.py
@@ -140,6 +140,16 @@ class GribFiles():
                         ds.drop(var)
                         continue
 
+                    # Some global models will start producing 12h accumulations at
+                    # lead times past 246h. These cause problems with the renaming,
+                    # so we can drop those fields.
+                    bad_12h_vars = ['APCP_P8_L1_GLL0_acc12h', \
+                        'APCP_P8_L1_GLC0_acc12h', 'APCP_P8_L1_GST0_acc12h']
+                    if 'global' in self.model and fhr != 12 and var in bad_12h_vars:
+                        print(f'dropping {var}')
+                        ds.drop(var)
+                        continue
+
                     # All the variables that need to be renamed. In most cases,
                     # exclude the "1h" ("6h" for global) accumulated variables
                     accum_freq = 6 if 'global' in self.model else 1

--- a/adb_graphics/datahandler/gribfile.py
+++ b/adb_graphics/datahandler/gribfile.py
@@ -1,4 +1,4 @@
-# pylint: disable=invalid-name,too-few-public-methods,too-many-locals
+# pylint: disable=invalid-name,too-few-public-methods,too-many-locals,too-many-branches
 
 '''
 Classes that load grib files.
@@ -79,7 +79,7 @@ class GribFiles():
         for var in ds.variables:
             suffix = var.split('_')[-1]
 
-            # Keeping lists of misbehaving "accumulated variables here because
+            # Keeping lists of misbehaving "accumulated" variables here because
             # there doesn't seem to be another way to know....
 
             if fcst_type == '01fcst':


### PR DESCRIPTION
Global models were recently extended to 336h, which revealed a change in the accumulated precip variable that happens at 246h, after which there are 12h accumulations.  This affects the renaming procedure, and crashes on the new variable.
This fix simply drops those new 12h accumulations.