### PR TITLE
Updated colorbars and full vertically integrated dusts for dust plots

### DIFF
--- a/adb_graphics/datahandler/gribdata.py
+++ b/adb_graphics/datahandler/gribdata.py
@@ -111,6 +111,18 @@ class UPPData(specs.VarSpec):
 
         return maxvals
 
+    def field_sum(self, values, variable2, level2, **kwargs):
+
+        # pylint: disable=unused-argument
+
+        ''' Return the sum of the values. '''
+
+        value2 = self.values(name=variable2, level=level2)
+        sum2 = values + value2
+        value2.close()
+
+        return sum2
+
     def field_diff(self, values, variable2, level2, **kwargs):
 
         # pylint: disable=unused-argument

--- a/adb_graphics/default_specs.yml
+++ b/adb_graphics/default_specs.yml
@@ -410,17 +410,8 @@ clwmr: # Cloud water Mixing Ratio
       nat: CLWMR_P0_L105_{grid}
       prs: CLWMR_P0_L100_{grid}
 coarsedust:
-  int: &coldust
-    clevs: [1, 2, 3, 4, 6, 8, 10, 15, 20, 30, 50, 75, 110, 150]
-    colors: smoke_colors
-    ncl_name: COLMD_P48_L200_{grid}_A62001_1
-    plot_airports: False
-    ticks: 0
-    title: Vertically Integrated Coarse Dust
-    transform: conversions.to_micro
-    unit: $mg/m^2$
-  sfc: &sfcdust
-    clevs: [1, 2, 3, 4, 6, 8, 10, 12, 15, 20, 30, 50, 75, 100]
+  sfc:
+    clevs: [10, 20, 30, 40, 60, 80, 100, 120, 150, 200, 300, 500, 750, 1000]
     colors: smoke_colors
     ncl_name: MASSDEN_P48_L103_{grid}_A62001_1
     plot_airports: False
@@ -480,13 +471,38 @@ dewp: # Dew point temperature
     wind: 10m
 finedust:
   int:
-    <<: *coldust
+    clevs: [1, 4, 7, 11, 15, 20, 25, 30, 40, 50, 75, 150, 250, 500]
+    colors: smoke_colors
     ncl_name: COLMD_P48_L200_{grid}_A62001
+    plot_airports: False
+    ticks: 0
     title: Vertically Integrated Fine Dust
+    transform: conversions.to_micro
+    unit: $mg/m^2$
   sfc:
-    <<: *sfcdust
+    clevs: [1, 2, 4, 6, 8, 12, 16, 20, 25, 30, 40, 60, 100, 200]
+    colors: smoke_colors
     ncl_name: MASSDEN_P48_L103_{grid}_A62001
+    plot_airports: False
     title: Near-Surface Fine Dust
+    transform: conversions.to_micrograms_per_m3
+    ticks: 0
+    unit: $\mu g/m^3$
+    wind: 10m
+full_int_dust:
+  int:
+    clevs: [1, 4, 7, 11, 15, 20, 25, 30, 40, 50, 75, 150, 250, 500]
+    colors: smoke_colors
+    ncl_name: COLMD_P48_L200_{grid}_A62001_1
+    plot_airports: False
+    ticks: 0
+    title: Vertically Integrated (Coarse + Fine) Dust
+    transform:
+      funcs: [conversions.to_micro, field_sum]
+      kwargs:
+        variable2: finedust
+        level2: int
+    unit: $mg/m^2$
 echotop: # Echo Top
   sfc:
     clevs: !!python/object/apply:numpy.arange [4, 50, 3]

--- a/adb_graphics/default_specs.yml
+++ b/adb_graphics/default_specs.yml
@@ -492,7 +492,7 @@ fullintdust: # Full vertically integrated dusts (Fine dust + Coarse dust)
   int:
     <<: *coldust
     ncl_name: COLMD_P48_L200_{grid}_A62001_1
-    title: Vertically Integrated (Coarse + Fine) Dusts
+    title: Vertically Integrated Dusts
     transform:
       funcs: [conversions.to_micro, field_sum]
       kwargs:

--- a/adb_graphics/default_specs.yml
+++ b/adb_graphics/default_specs.yml
@@ -409,8 +409,17 @@ clwmr: # Cloud water Mixing Ratio
     ncl_name: 
       nat: CLWMR_P0_L105_{grid}
       prs: CLWMR_P0_L100_{grid}
-coarsedust:
-  sfc:
+coarsedust: # Coarse dust
+  int: &coldust
+    clevs: [1, 4, 7, 11, 15, 20, 25, 30, 40, 50, 75, 150, 250, 500]
+    colors: smoke_colors
+    ncl_name: COLMD_P48_L200_{grid}_A62001_1
+    plot_airports: False
+    ticks: 0
+    title: Vertically Integrated Coarse Dust
+    transform: conversions.to_micro
+    unit: $mg/m^2$
+  sfc: &sfcdust
     clevs: [10, 20, 30, 40, 60, 80, 100, 120, 150, 200, 300, 500, 750, 1000]
     colors: smoke_colors
     ncl_name: MASSDEN_P48_L103_{grid}_A62001_1
@@ -469,40 +478,26 @@ dewp: # Dew point temperature
     transform: conversions.k_to_f
     unit: F
     wind: 10m
-finedust:
+finedust: # Fine dust
   int:
-    clevs: [1, 4, 7, 11, 15, 20, 25, 30, 40, 50, 75, 150, 250, 500]
-    colors: smoke_colors
+    <<: *coldust
     ncl_name: COLMD_P48_L200_{grid}_A62001
-    plot_airports: False
-    ticks: 0
     title: Vertically Integrated Fine Dust
-    transform: conversions.to_micro
-    unit: $mg/m^2$
   sfc:
+    <<: *sfcdust
     clevs: [1, 2, 4, 6, 8, 12, 16, 20, 25, 30, 40, 60, 100, 200]
-    colors: smoke_colors
     ncl_name: MASSDEN_P48_L103_{grid}_A62001
-    plot_airports: False
     title: Near-Surface Fine Dust
-    transform: conversions.to_micrograms_per_m3
-    ticks: 0
-    unit: $\mu g/m^3$
-    wind: 10m
-full_int_dust:
+fullintdust: # Full vertically integrated dusts (Fine dust + Coarse dust)
   int:
-    clevs: [1, 4, 7, 11, 15, 20, 25, 30, 40, 50, 75, 150, 250, 500]
-    colors: smoke_colors
+    <<: *coldust
     ncl_name: COLMD_P48_L200_{grid}_A62001_1
-    plot_airports: False
-    ticks: 0
-    title: Vertically Integrated (Coarse + Fine) Dust
+    title: Vertically Integrated (Coarse + Fine) Dusts
     transform:
       funcs: [conversions.to_micro, field_sum]
       kwargs:
         variable2: finedust
         level2: int
-    unit: $mg/m^2$
 echotop: # Echo Top
   sfc:
     clevs: !!python/object/apply:numpy.arange [4, 50, 3]

--- a/image_lists/rrfs_subset.yml
+++ b/image_lists/rrfs_subset.yml
@@ -54,7 +54,7 @@ hourly:
       - sfc
     flru:
       - sfc
-    full_int_dust:
+    fullintdust:
       - int
     G113bt:
       - sat

--- a/image_lists/rrfs_subset.yml
+++ b/image_lists/rrfs_subset.yml
@@ -35,7 +35,6 @@ hourly:
       - mid
       - total
     coarsedust:
-      - int
       - sfc
     cpofp:
       - sfc
@@ -50,12 +49,13 @@ hourly:
     emissions:
       - sfc
     finedust:
-      - int
       - sfc
     firewx:
       - sfc
     flru:
       - sfc
+    full_int_dust:
+      - int
     G113bt:
       - sat
     G114bt:


### PR DESCRIPTION
1) Changed the range of the colorbars.
<img width="712" alt="near_sfc_fine_dust" src="https://user-images.githubusercontent.com/22350118/227618168-7a553f30-137c-4241-9b84-75adcb0beab4.png">
<img width="710" alt="near_sfc_coarse_dust" src="https://user-images.githubusercontent.com/22350118/227618189-ed366418-fea7-46db-a01d-ace9e40d0ac7.png">
2) Combined the vertically integrated dusts (fine and coarse) into one plot.
<img width="711" alt="full_int_dust" src="https://user-images.githubusercontent.com/22350118/227618196-f99f5aa5-0f9f-4a2e-a085-e271a85f45f6.png">
