### PR TITLE
Changes to reorient the HRRR Hawaii graphics.

### DIFF
--- a/adb_graphics/datahandler/gribdata.py
+++ b/adb_graphics/datahandler/gribdata.py
@@ -636,7 +636,8 @@ class fieldData(UPPData):
         lat = self.ds[lat_var]
 
         grid_info = {}
-        grid_info['corners'] = self.corners
+        if self.model != 'hrrrhi':
+            grid_info['corners'] = self.corners
         if self.grid_suffix in ['GLC0']:
             attrs = ['Latin1', 'Latin2', 'Lov']
             grid_info['projection'] = 'lcc'
@@ -668,6 +669,12 @@ class fieldData(UPPData):
             val = val[0] if isinstance(val, np.ndarray) else val
             grid_info[bm_arg] = val
             del val
+
+            if self.model == 'hrrrhi':
+                grid_info['lat_0'] = 20.44
+                grid_info['lon_0'] = 202.54
+                grid_info['width'] = 2000000
+                grid_info['height'] = 2000000
 
         del lat
 

--- a/adb_graphics/default_specs.yml
+++ b/adb_graphics/default_specs.yml
@@ -85,6 +85,7 @@
     ncl_name:
       rrfs: WEASD_P8_L1_{grid}_acc
       hrrr: WEASD_P8_L1_{grid}_acc1h
+      hrrrhi: WEASD_P8_L1_{grid}_acc1h
       rap: WEASD_P8_L1_{grid}_acc1h
     ticks: 0
     title: 1 hr Accumulated Snow Using 10:1 Ratio


### PR DESCRIPTION
Changes to reorient the HRRR Hawaii graphics.  Corners are no longer used, and instead, a center point, width, and height are provided to Basemap.  An option for a zoomed domain is also provided.

![image](https://user-images.githubusercontent.com/58485074/235265895-1ae9acba-dc57-451c-a9ff-9305a7179edf.png)
![image](https://user-images.githubusercontent.com/58485074/235265935-076c195c-f40c-4ccf-8fb5-b0fa4e3f5109.png)
