### PR TITLE
changes to temperature colors (2m T, sfc T, soil T, and T_2ds)

### DIFF
--- a/adb_graphics/default_specs.yml
+++ b/adb_graphics/default_specs.yml
@@ -1261,11 +1261,11 @@ soilm: # Soil Moisture Availability
     unit: "%"
 soilt: # Soil Temperature
   0cm: &soilt_levs
-    clevs: !!python/object/apply:numpy.arange [240, 331, 2]
-    cmap: jet
+    clevs: !!python/object/apply:numpy.arange [235, 331, 5]
+    cmap: gist_ncar
     colors: tsfc_colors
     ncl_name: TSOIL_P0_2L106_{grid}
-    ticks: 4
+    ticks: 5
     title: Soil Temperature at Sfc
     unit: K
   1cm:
@@ -1357,8 +1357,8 @@ ssrun: # Storm Surface Runoff
     unit: in
 temp: # Temperature
   2ds: # 2m - Sfc
-    clevs: !!python/object/apply:numpy.arange [-16, 17, 2]
-    cmap: seismic
+    clevs: !!python/object/apply:numpy.arange [-32, 33, 2]
+    cmap: Spectral_r
     colors: centered_diff
     ncl_name: TMP_P0_L103_{grid} # 2m Temp
     ticks: 2
@@ -1370,10 +1370,10 @@ temp: # Temperature
         level2: sfc
     unit: F
     wind: False
-  2m:
+  2m: &sfc_temp
     annotate: True
-    clevs: !!python/object/apply:numpy.arange [-60, 121, 4]
-    cmap: jet
+    clevs: !!python/object/apply:numpy.arange [-50, 141, 10]
+    cmap: gist_ncar
     colors: tsfc_colors
     ncl_name: TMP_P0_L103_{grid}
     ticks: 10
@@ -1441,13 +1441,8 @@ temp: # Temperature
         hatches: ['', '...']
         levels: [0, 925]
   sfc:
-    clevs: !!python/object/apply:numpy.arange [-60, 120, 4]
-    cmap: jet
-    colors: tsfc_colors
+    <<: *sfc_temp
     ncl_name: TMP_P0_L1_{grid}
-    ticks: 20
-    transform: conversions.k_to_f
-    unit: F
     wind: False
   ua:
     <<: *ua_temp

--- a/adb_graphics/specs.py
+++ b/adb_graphics/specs.py
@@ -435,17 +435,13 @@ class VarSpec(abc.ABC):
     @property
     def tsfc_colors(self) -> np.ndarray:
 
-        ''' Default color map for Surface Temperature '''  # WeatherBell-inspired scheme
+        ''' Default color map for Surface Temperature '''
 
-        temp1 = cm.get_cmap('cool_r', 8)(range(0, 8))
-        temp2 = cm.get_cmap('BuGn', 6)(range(2, 6))
-        temp3 = cm.get_cmap('Greens_r', 4)(range(0, 4))
-        temp4 = cm.get_cmap('RdPu_r', 8)(range(0, 8))
-        temp5 = cm.get_cmap('BuPu', 5)(range(0, 4))
-        temp6 = cm.get_cmap('RdYlBu_r', 10)(range(1, 10))
-        temp7 = cm.get_cmap('RdYlGn', 10)(range(0, 10))
-
-        return np.concatenate((temp1, temp2, temp3, temp4, temp5, temp6, temp7))
+        purples = cm.get_cmap('Purples', 16)([14, 12, 8, 6, 4, 2])
+        ncar = cm.get_cmap(self.vspec.get('cmap'), 128) \
+                          ([15, 20, 25, 33, 50, 60, 70, 80, 85, 90, 115])
+        grays = cm.get_cmap('Greys', 15)([2, 4, 6, 8])
+        return np.concatenate((purples, ncar, grays))
 
     @property
     def terrain_colors(self) -> np.ndarray:


### PR DESCRIPTION
These color table changes were requested to improve the various temperature graphics:
- sfc T
- 2m T
- T 2ds
- soil T
Sample graphics provided below.

passed pylint but failed pytest, will provide fix for that as needed.

-------------------------

![image](https://github.com/NOAA-GSL/pygraf/assets/56739562/149c5e9f-a728-4763-8bd5-51f3e2532351)
![image](https://github.com/NOAA-GSL/pygraf/assets/56739562/c70c8ffd-9750-4eb6-a8fa-a2bf45e29edd)

![image](https://github.com/NOAA-GSL/pygraf/assets/56739562/eaaa110c-23dc-432e-9e9b-97ef7da6ee16)
![image](https://github.com/NOAA-GSL/pygraf/assets/56739562/faa5acf7-a3bf-4ff8-823c-52749cb4b1d2)

![image](https://github.com/NOAA-GSL/pygraf/assets/56739562/d9ed596f-5891-42cb-a73c-b8ee37a97762)
![image](https://github.com/NOAA-GSL/pygraf/assets/56739562/e3cc191c-74a6-46bf-8b85-c630c56abacb)

![image](https://github.com/NOAA-GSL/pygraf/assets/56739562/64e92186-6907-4a5c-a625-70d7e7d6ef36)
![image](https://github.com/NOAA-GSL/pygraf/assets/56739562/3e95d1c5-9acb-474e-bead-cd64f25c0a1c)