### PR TITLE
Extend and add colors for max updraft helicity, hourly and run total

### DIFF
--- a/adb_graphics/default_specs.yml
+++ b/adb_graphics/default_specs.yml
@@ -699,29 +699,35 @@ hlcy: # Helicity
     title: 2-5km Min Updraft Helicity (over prv hr)
   mx02: &hlcy_mx02 # Hourly maximum of updraft helicity over 0-2 km layer
     <<: *hlcy
-    clevs: !!python/object/apply:numpy.arange [12.5, 150.5, 12.5]
+    clevs: !join_ranges [[12.5, 87.6, 12.5], [100, 301, 25]]
+    colors: rainbow16_colors
     ncl_name: MXUPHL_P8_2L103_{grid}_max1h
     split: True
-    ticks: 12.5
+    ticks: 0
     title: 0-2km Max Updraft Helicity (over prv hr)
   mx03: &hlcy_mx03 # Hourly maximum of updraft helicity over 0-3 km layer
     <<: *hlcy
-    clevs: !!python/object/apply:numpy.arange [12.5, 150.5, 12.5]
+    clevs: !join_ranges [[12.5, 87.6, 12.5], [100, 301, 25]]
+    colors: rainbow16_colors
     ncl_name: MXUPHL_P8_2L103_{grid}_max1h
     split: True
-    ticks: 12.5
+    ticks: 0
     title: 0-3km Max Updraft Helicity (over prv hr)
   mx16: &hlcy_mx16 # Hourly maximum of updraft helicity over 1-6 km layer
     <<: *hlcy
-    clevs: !!python/object/apply:numpy.arange [25, 301, 25]
+    clevs: !join_ranges [[25, 176, 25], [200, 601, 50]]
+    colors: rainbow16_colors
     ncl_name: MXUPHL_P8_2L103_{grid}_max1h
     split: True
+    ticks: 0
     title: 1-6km Max Updraft Helicity (over prv hr)
   mx25: &hlcy_mx25 # Hourly maximum of updraft helicity over 2-5 km layer
     <<: *hlcy
-    clevs: !!python/object/apply:numpy.arange [25, 301, 25]
+    clevs: !join_ranges [[25, 176, 25], [200, 601, 50]]
+    colors: rainbow16_colors
     ncl_name: MXUPHL_P8_2L103_{grid}_max1h
     split: True
+    ticks: 0
     title: 2-5km Max Updraft Helicity (over prv hr)
   sr01: # 0-1 km Storm Relative Helicity
     <<: *hlcy

--- a/adb_graphics/specs.py
+++ b/adb_graphics/specs.py
@@ -364,6 +364,16 @@ class VarSpec(abc.ABC):
         return np.flip(self.rainbow12_colors, 0)
 
     @property
+    def rainbow16_colors(self) -> np.ndarray:
+
+        ''' Default color map for helicity '''
+
+        grays = cm.get_cmap('Greys', 5)([0, 2])
+        ncar = cm.get_cmap(self.vspec.get('cmap'), 128) \
+                          ([9, 15, 18, 20, 25, 48, 57, 65, 74, 79, 87, 94, 102, 109, 120])
+        return np.concatenate((grays, ncar))
+
+    @property
     def shear_colors(self) -> np.ndarray:
 
         ''' Default color map for Vertical Shear '''


### PR DESCRIPTION
This change extends the upper limit for maximum updraft helicity, both hourly and run total.  The change was requested by Jack Settelmaier through Jacob Carley and Steve Weygandt.

Change includes using "join_ranges" method to keep the number of new colors limited (from 12 to 16 levels) while roughly doubling the upper limit. Fields changed are 0-3km and 2-5km max UH (also changed 0-2km and 1-6km, but those aren't currently plotted.)

passed pylint.

Samples below (old and new).
![image](https://github.com/NOAA-GSL/pygraf/assets/56739562/04e4f573-7d33-477c-b895-f296a0542ef7)
![image](https://github.com/NOAA-GSL/pygraf/assets/56739562/2d16c490-2b62-4853-9c86-743280631efe)

![image](https://github.com/NOAA-GSL/pygraf/assets/56739562/b01445b5-524c-4285-836d-f4d517cb4c1d)
![image](https://github.com/NOAA-GSL/pygraf/assets/56739562/888637a8-86e8-4f7e-b608-ba277e9271a3)
