### PR TITLE
RRFS A Ensemble changes

### DIFF
--- a/adb_graphics/figure_builders.py
+++ b/adb_graphics/figure_builders.py
@@ -99,6 +99,10 @@ def parallel_maps(cla, fhr, ds, level, model, spec, variable, workdir,
             if index in (0, 8):
                 current_ax.axis('off')
 
+            # If we have less than 10 members, skip the remaining panels.
+            if index > cla.ens_size:
+                continue
+
             # Shenanigans to match ensemble member to panel index
             mem = 0 if index == 4 else index
             mem = mem if mem < 4 else index - 1

--- a/adb_graphics/figure_builders.py
+++ b/adb_graphics/figure_builders.py
@@ -91,7 +91,7 @@ def parallel_maps(cla, fhr, ds, level, model, spec, variable, workdir,
 
     for index, current_ax in enumerate(axes):
 
-        if current_ax is axes[-1]:
+        if current_ax is axes[-1] or index == cla.ens_size:
             last_panel = True
         mem = None
         if cla.graphic_type == 'enspanel':

--- a/create_graphics.py
+++ b/create_graphics.py
@@ -581,6 +581,7 @@ def graphics_driver(cla):
             # mins (default is 3 to address most CONUS-sized domains)
             if old_enough:
                 fcst_hours.remove(fhr)
+                fhr_as_list = [fhr]
             else:
                 if cla.all_leads:
                     # Wait on the missing file for an arbitrary 90% of wait time
@@ -637,7 +638,7 @@ def graphics_driver(cla):
                             )
             else:
                 gribfiles = gribfile.GribFiles(
-                    coord_dims={'ens_mem': ens_members},
+                    coord_dims={'ens_mem': ens_members, 'fcst_hr': fhr_as_list},
                     filenames={'free_fcst': grib_paths},
                     filetype=cla.file_type,
                     model=cla.images[0],

--- a/image_lists/rrfs_ens.yml
+++ b/image_lists/rrfs_ens.yml
@@ -6,8 +6,6 @@ hourly:
     acsnw:
       - sfc
     cape:
-      - mu
-      - mul
       - mx90mb
       - sfc
     cin:


### PR DESCRIPTION
These are the changes that were necessary to get the RRFS A Ensemble graphics running.  Previously, the figure_builders.py would check would check for members even if they weren't present, and even if ens_size was set to a number lower than the default (10).  Now it will skip looking for members higher than theens_size.  In create_graphics.py, The fhr is needed in the call to create_maps as a list, or parallel_maps will crash.  The fields for most unstable CAPE and most unstable layer CAPE are not available, and are removed from the rrfs_ens.yml file.