### PR TITLE
use temperature colors for dewp point temp

### DIFF
--- a/adb_graphics/default_specs.yml
+++ b/adb_graphics/default_specs.yml
@@ -475,11 +475,11 @@ ctop: # Cloud top height
     unit: kft asl
 dewp: # Dew point temperature
   2m:
-    clevs: [-60, -50, -40, -30, -20, -10, 0, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32, 34, 36, 38, 40, 42, 44, 46, 48, 50, 52, 54, 56, 58, 60, 62, 64, 66, 68, 70, 80, 90, 100, 110, 120]
-    cmap: Carbone42_r
-    colors: dewp_colors
+    clevs: !!python/object/apply:numpy.arange [-50, 141, 10]
+    cmap: gist_ncar
+    colors: tsfc_colors
     ncl_name: DPT_P0_L103_{grid}
-    ticks: -4
+    ticks: 10
     transform: conversions.k_to_f
     unit: F
     wind: 10m

--- a/adb_graphics/specs.py
+++ b/adb_graphics/specs.py
@@ -102,15 +102,6 @@ class VarSpec(abc.ABC):
         return np.concatenate((grays, nws, white))
 
     @property
-    def dewp_colors(self) -> np.ndarray:
-
-        ''' Default color map for Dew point temperature '''
-
-        ctable = ctables.colortables.get_colortable(self.vspec.get('cmap')) \
-                    (range(0, 42, 1)) # Carbone42_r
-        return ctable
-
-    @property
     def fire_power_colors(self) -> np.ndarray:
 
         ''' Default color map for fire power plot. '''


### PR DESCRIPTION
this change was requested by Stan, based on discussions with other end users.  There was consensus that dew point fields should use the same color table as temperatures, to make comparisons easier.

Change was made to `default_specs.yml`.  The `dewp_colors` table was removed from the specs.py file as well.

before/after examples below.

passed pylint.

![image](https://github.com/NOAA-GSL/pygraf/assets/56739562/b9a4aa74-23cf-4257-8c58-5e69f90fd390)
![image](https://github.com/NOAA-GSL/pygraf/assets/56739562/6076d2b9-ae59-465e-bd45-fee9ae6ce018)

