### PR TITLE
include Jaymes Kenyon to pygraf CODEOWNERS file for reviewing

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,4 +3,4 @@
 
 # These owners will be the default owners for everything in the repo.
 #*       @defunkt
-*       @cshartsough @christinaholtNOAA @Brian-Jamison @kayeekayee
+*       @cshartsough @christinaholtNOAA @Brian-Jamison @kayeekayee @jaymes-kenyon


### PR DESCRIPTION
need to add Jaymes to the .github/CODEOWNERS file so he can be included in the "approving reviewers" and the default list.
