### PR TITLE
Updating the RRFS GRIB2 variable handle for "MSTAV"

### DIFF
--- a/adb_graphics/default_specs.yml
+++ b/adb_graphics/default_specs.yml
@@ -1261,7 +1261,7 @@ soilm: # Soil Moisture Availability
       hrrrhi: MSTAV_P0_L106_{grid}
       hrrrcar: MSTAV_P0_L106_{grid}
       rap: MSTAV_P0_L106_{grid}
-      rrfs: MSTAV_P0_2L106_{grid}
+      rrfs: MSTAV_P0_L106_{grid}
     ticks: 0
     title: Soil Moisture Availability
     unit: "%"


### PR DESCRIPTION
A previous commit to the UPP repository (https://github.com/NOAA-EMC/UPP/commit/83e59b5d92ec678bcab11dd59919fac189a11a4c) resulted in a change to the RRFS GRIB2 variable handle for soil moisture availability (MSTAV). As a result of this change, Python graphics are failing in RRFS-B. Running an "ncl_filedump" on a recent RRFS-B GRIB2 file indicates that the new variable handle is "MSTAV_P0_L106_GLC0".  This update to pygraf has been successfully used in a RRFS CONUS 3-km retro on Hera.