### PR TITLE
RRFS: add cloud-base height and correct the ceiling-exp2 handle

### DIFF
--- a/adb_graphics/default_specs.yml
+++ b/adb_graphics/default_specs.yml
@@ -347,7 +347,7 @@ ceilexp: # Ceiling - experimental
 ceilexp2: # Ceiling - experimental no.2
   ua:
     <<: *ceil
-    ncl_name: HGT_P0_L2_{grid}
+    ncl_name: CEIL_P0_L2_{grid}
     title: Ceiling (exp-2)
 cfrzr: # Categorical Freezing Rain
   sfc:

--- a/adb_graphics/default_specs.yml
+++ b/adb_graphics/default_specs.yml
@@ -379,6 +379,11 @@ cin: # Surface Convective Inhibition
   sfclt:
     <<: *sfc_cin
     title: Surface CIN < -50
+cloudbase: # Cloud-base height
+  ua:
+    <<: *ceil
+    ncl_name: HGT_P0_L2_{grid}
+    title: Cloud-Base Height
 cloudcover:
   bndylay: &cld_cover # PBL ... 1 km Cloud Cover
     clevs: [2, 5, 10, 20, 30, 40, 50, 60, 70, 80, 90, 95]

--- a/image_lists/rrfs_subset.yml
+++ b/image_lists/rrfs_subset.yml
@@ -28,6 +28,8 @@ hourly:
       - ua
     cin:
       - sfc
+    cloudbase:
+      - ua
     cloudcover:
       - bndylay
       - high


### PR DESCRIPTION
(1) This update creates plots of cloud-base height in RRFS applications, addressing issue #228.  The plotting conventions used for ceiling are applied to  these plots. These updates have been tested in a RRFS case (CONUS domain) on Jet.  The attached screenshot shows a comparison between a ceiling plot (left panel) and the new cloud-base plot (right panel).
(2) Additionally, the NCL .grib2 handle for the ceiling-exp2 field has been updated/corrected. 

<img width="1420" alt="Screenshot 2023-10-25 at 2 42 09 PM" src="https://github.com/NOAA-GSL/pygraf/assets/14337181/94b834bc-fb02-4569-8cd0-82d130a4ca53">
