### PR TITLE
Fix rrfs a issues

### DIFF
--- a/adb_graphics/default_specs.yml
+++ b/adb_graphics/default_specs.yml
@@ -1577,8 +1577,8 @@ temp: # Temperature
     wind: False
   2m: &sfc_temp
     annotate: True
-    clevs: !!python/object/apply:numpy.arange [-50, 141, 10]
-    cmap: gist_ncar
+    clevs: !!python/object/apply:numpy.arange [-60, 121, 4] 
+    cmap: jet
     colors: tsfc_colors
     ncl_name: TMP_P0_L103_{grid}
     ticks: 10

--- a/adb_graphics/default_specs.yml
+++ b/adb_graphics/default_specs.yml
@@ -86,7 +86,7 @@
       hrrr: WEASD_P8_L1_{grid}_acc1h
       hrrrhi: WEASD_P8_L1_{grid}_acc1h
       rap: WEASD_P8_L1_{grid}_acc1h
-      rrfs: TSNOWP_P8_L1_{grid}_acc1h
+      rrfs: TSNOWP_P8_L1_{grid}_acc
     ticks: 0
     title: 1 hr Accumulated Snow Using 10:1 Ratio
     transform: [conversions.kgm2_to_in, conversions.weasd_to_1hsnw]

--- a/adb_graphics/figures/maps.py
+++ b/adb_graphics/figures/maps.py
@@ -422,17 +422,6 @@ class DataMap():
                                fontsize=10,
                                inline=1,
                                )
-                    #
-                    # #old routine, makes white text on black bounding box
-                    # clab = plt.clabel(cc, levels[::4],
-                    #                   colors='k',
-                    #                   fmt='%1.0f',
-                    #                   fontsize=10,
-                    #                   inline=1,
-                    #                   )
-                    # # Set the background color for the line labels to black
-                    # _ = [txt.set_bbox(dict(color='k')) for txt in clab]
-
                 except ValueError:
                     print(f'Cannot add contour labels to map for {self.field.short_name} \
                             {self.field.level}')

--- a/adb_graphics/figures/maps.py
+++ b/adb_graphics/figures/maps.py
@@ -396,9 +396,22 @@ class DataMap():
 
         ''' Draw the contour fields requested. '''
 
+        model_name = self.model_name
+        print(f'model_name = {model_name}')
+        main_field = self.field.short_name
+        print(f'main_field = {main_field}')
+
         for contour_field in self.contour_fields:
             levels = contour_field.contour_kwargs.pop('levels',
                                                       contour_field.clevs)
+
+            print(f'levels are {levels}')
+            print(f'contour_field.short_name = {contour_field.short_name}')
+            print(f'self.map.tile = {self.map.tile}')
+            if model_name == "RRFS NA 3km" and main_field == "totp" and \
+               contour_field.short_name == "pres" and self.map.tile == "full":
+                levels = np.arange(650, 1051, 8)
+                print(f'levels are now {levels}')
 
             cc = self._draw_field(ax=ax,
                                   field=contour_field,
@@ -409,13 +422,13 @@ class DataMap():
             if contour_field.short_name not in not_labeled:
                 try:
                     clab = plt.clabel(cc, levels[::4],
-                                      colors='w',
+                                      colors='k',
                                       fmt='%1.0f',
                                       fontsize=10,
                                       inline=1,
                                       )
-                    # Set the background color for the line labels to black
-                    _ = [txt.set_bbox(dict(color='k')) for txt in clab]
+                    # # Set the background color for the line labels to black
+                    # _ = [txt.set_bbox(dict(color='k')) for txt in clab]
 
                 except ValueError:
                     print(f'Cannot add contour labels to map for {self.field.short_name} \

--- a/adb_graphics/figures/maps.py
+++ b/adb_graphics/figures/maps.py
@@ -397,21 +397,16 @@ class DataMap():
         ''' Draw the contour fields requested. '''
 
         model_name = self.model_name
-        print(f'model_name = {model_name}')
         main_field = self.field.short_name
-        print(f'main_field = {main_field}')
 
         for contour_field in self.contour_fields:
             levels = contour_field.contour_kwargs.pop('levels',
                                                       contour_field.clevs)
 
-            print(f'levels are {levels}')
-            print(f'contour_field.short_name = {contour_field.short_name}')
-            print(f'self.map.tile = {self.map.tile}')
-            if model_name == "RRFS NA 3km" and main_field == "totp" and \
-               contour_field.short_name == "pres" and self.map.tile == "full":
-                levels = np.arange(650, 1051, 8)
-                print(f'levels are now {levels}')
+            if model_name in ["RAP-NCEP", "RRFS-NCEP", "RRFS NA 3km"]:
+                if main_field == "totp" and contour_field.short_name == "pres" and \
+                   self.map.tile == "full":
+                    levels = np.arange(650, 1051, 8)
 
             cc = self._draw_field(ax=ax,
                                   field=contour_field,
@@ -421,12 +416,20 @@ class DataMap():
                                   )
             if contour_field.short_name not in not_labeled:
                 try:
-                    clab = plt.clabel(cc, levels[::4],
-                                      colors='k',
-                                      fmt='%1.0f',
-                                      fontsize=10,
-                                      inline=1,
-                                      )
+                    plt.clabel(cc, levels[::4],
+                               colors='k',
+                               fmt='%1.0f',
+                               fontsize=10,
+                               inline=1,
+                               )
+                    #
+                    # #old routine, makes white text on black bounding box
+                    # clab = plt.clabel(cc, levels[::4],
+                    #                   colors='k',
+                    #                   fmt='%1.0f',
+                    #                   fontsize=10,
+                    #                   inline=1,
+                    #                   )
                     # # Set the background color for the line labels to black
                     # _ = [txt.set_bbox(dict(color='k')) for txt in clab]
 

--- a/adb_graphics/specs.py
+++ b/adb_graphics/specs.py
@@ -445,13 +445,17 @@ class VarSpec(abc.ABC):
     @property
     def tsfc_colors(self) -> np.ndarray:
 
-        ''' Default color map for Surface Temperature '''
+        ''' Default color map for Surface Temperature '''  # WeatherBell-inspired scheme
 
-        purples = cm.get_cmap('Purples', 16)([14, 12, 8, 6, 4, 2])
-        ncar = cm.get_cmap(self.vspec.get('cmap'), 128) \
-                          ([15, 20, 25, 33, 50, 60, 70, 80, 85, 90, 115])
-        grays = cm.get_cmap('Greys', 15)([2, 4, 6, 8])
-        return np.concatenate((purples, ncar, grays))
+        temp1 = cm.get_cmap('cool_r', 8)(range(0, 8))
+        temp2 = cm.get_cmap('BuGn', 6)(range(2, 6))
+        temp3 = cm.get_cmap('Greens_r', 4)(range(0, 4))
+        temp4 = cm.get_cmap('RdPu_r', 8)(range(0, 8))
+        temp5 = cm.get_cmap('BuPu', 5)(range(0, 4))
+        temp6 = cm.get_cmap('RdYlBu_r', 10)(range(1, 10))
+        temp7 = cm.get_cmap('RdYlGn', 10)(range(0, 10))
+
+        return np.concatenate((temp1, temp2, temp3, temp4, temp5, temp6, temp7))
 
     @property
     def terrain_colors(self) -> np.ndarray:


### PR DESCRIPTION
These changes correct the problems with the numerous black boxes from contour labels.  Below is an example:

![image](https://github.com/NOAA-GSL/pygraf/assets/58485074/e066e17b-473c-4373-a5aa-966b0231d921)

The number of contours has been changed as well, from every 2mb to every 8mb, reducing the cluttered contour lines.

Accumulated snow and precip plots are working:

![image](https://github.com/NOAA-GSL/pygraf/assets/58485074/fe0d8655-2b77-42ed-a8e8-1baf26ddaed0)
![image](https://github.com/NOAA-GSL/pygraf/assets/58485074/d389c4b6-0cc6-46f8-bb02-13aea105cb14)

Additionally, Craig's new color table for skin and 2m temperature has been implemented.