### PR TITLE
WFIP3 Domains for HRRR

### DIFF
--- a/adb_graphics/default_specs.yml
+++ b/adb_graphics/default_specs.yml
@@ -1745,6 +1745,8 @@ u:
     ncl_name: UGRD_P0_L103_{grid}
     transform: conversions.ms_to_kt
   80m: *agl_uwind
+  160m: *agl_uwind
+  320m: *agl_uwind
   5mb: &ua_uwind
     ncl_name:
       prs: UGRD_P0_L100_{grid}
@@ -1807,6 +1809,8 @@ v:
     ncl_name: VGRD_P0_L103_{grid}
     transform: conversions.ms_to_kt
   80m: *agl_wind
+  160m: *agl_wind
+  320m: *agl_wind
   5mb: &ua_vwind
     ncl_name:
       prs: VGRD_P0_L100_{grid}
@@ -1970,12 +1974,26 @@ wspeed: # Wind Speed
   10mb:
     <<: *ua_wspeed_high
     title: 10mb Wind
+  160m:
+    <<: *ua_wspeed
+    title: 160m Wind
+    transform:
+      funcs: [vector_magnitude, conversions.ms_to_kt]
+      kwargs:
+        field2: VGRD_P0_L103_{grid}
   20mb:
     <<: *ua_wspeed_high
     title: 20mb Wind
   250mb:
     <<: *ua_wspeed_high
     title: 250mb Wind
+  320m:
+    <<: *ua_wspeed
+    title: 320m Wind
+    transform:
+      funcs: [vector_magnitude, conversions.ms_to_kt]
+      kwargs:
+        field2: VGRD_P0_L103_{grid}
   80m:
     <<: *ua_wspeed
     title: 80m Wind

--- a/adb_graphics/default_specs.yml
+++ b/adb_graphics/default_specs.yml
@@ -1977,10 +1977,6 @@ wspeed: # Wind Speed
   160m:
     <<: *ua_wspeed
     title: 160m Wind
-    transform:
-      funcs: [vector_magnitude, conversions.ms_to_kt]
-      kwargs:
-        field2: VGRD_P0_L103_{grid}
   20mb:
     <<: *ua_wspeed_high
     title: 20mb Wind
@@ -1990,17 +1986,9 @@ wspeed: # Wind Speed
   320m:
     <<: *ua_wspeed
     title: 320m Wind
-    transform:
-      funcs: [vector_magnitude, conversions.ms_to_kt]
-      kwargs:
-        field2: VGRD_P0_L103_{grid}
   80m:
     <<: *ua_wspeed
     title: 80m Wind
-    transform:
-      funcs: [vector_magnitude, conversions.ms_to_kt]
-      kwargs:
-        field2: VGRD_P0_L103_{grid}
   850mb:
     <<: *ua_wspeed
     contours:

--- a/adb_graphics/figures/maps.py
+++ b/adb_graphics/figures/maps.py
@@ -69,6 +69,8 @@ TILE_DEFS = {
     'Taiwan': {'corners': [19, 28, 116, 126], 'stride': 1, 'length': 5},
     'VortexSE': {'corners': [30, 37, -92.5, -82], 'stride': 4, 'length': 4},
     'WAtlantic': {'corners': [-0.25, 50.25, 261.75, 330.25], 'stride': 5, 'length': 5},
+    'WFIP3-d01': {'corners': [33.66, 46.86, -78.83, -61.01], 'stride': 10, 'length': 4},
+    'WFIP3-d02': {'corners': [37.84, 43.22, -74.77, -66.50], 'stride': 5, 'length': 5},
     'WPacific': {'corners': [-40, 50, 90, 240], 'stride': 10, 'length': 5},
 }
 
@@ -110,6 +112,8 @@ class Map():
         self.tile = kwargs.get('tile', 'full')
         self.airports = self.load_airports(airport_fn)
 
+        if self.model == 'hrrr' and 'WFIP3' in self.tile:
+            self.grid_info.update({'lat_1': 40.6, 'lat_2': 40.6, 'lon_0': 289.2})
         if self.model != 'hrrrhi':
             if self.tile in FULL_TILES:
                 self.corners = self.grid_info.pop('corners')
@@ -657,6 +661,12 @@ class DataMap():
             if self.map.model == 'globalCONUS':
                 stride = int(round(stride / 2.5))
                 length = 5
+            if self.map.model == 'hrrr' and self.model_name == 'WFIP3-FULL' and \
+               tile == 'WFIP3-d02':
+                stride = 6
+            if self.map.model == 'hrrr' and self.model_name == 'WFIP3-NEST' and \
+               tile == 'WFIP3-d02':
+                stride = 17
 
         mask = np.ones_like(u)
         mask[::stride, ::stride] = 0

--- a/image_lists/wfip_subset.yml
+++ b/image_lists/wfip_subset.yml
@@ -1,0 +1,185 @@
+hourly:
+  model: hrrr
+  variables:
+    1hsnw:
+      - sfc
+    1ref:
+      - 1000m
+    acfrozr:
+      - sfc
+    acfrzr:
+      - sfc
+    acpcp:
+      - sfc
+    acsnod:
+      - sfc
+    acsnw:
+      - sfc
+    cape:
+      - mu
+      - mul
+      - mx90mb
+      - sfc
+    ceil:
+      - ua
+    ceilexp:
+      - ua
+    ceilexp2:
+      - ua
+    cin:
+      - sfc
+    cloudcover:
+      - bndylay
+      - high
+      - low
+      - mid
+      - total
+    cpofp:
+      - sfc
+    cref:
+      - sfc
+    ctop:
+      - ua
+    dewp:
+      - 2m
+    echotop:
+      - sfc
+    firewx:
+      - sfc
+    flru:
+      - sfc
+    G113bt:
+      - sat
+    G114bt:
+      - sat
+    G123bt:
+      - sat
+    G124bt:
+      - sat
+    gust:
+      - 10m
+    hail:
+      - max
+      - maxsfc
+    hailcast:
+      - maxsfc
+    hlcy:
+      - in25
+      - mn02
+      - mn03
+      - mn25
+      - mx02
+      - mx03
+      - mx25
+      - sr01
+      - sr03
+    hlcytot:
+      - mn02
+      - mn03
+      - mn25
+      - mx02
+      - mx03
+      - mx25
+    hpbl:
+      - sfc
+    lcl:
+      - sfc
+    lhtfl:
+      - sfc
+    li:
+      - best
+      - sfc
+    ltg3:
+      - sfc
+    mfrp:
+      - sfc
+    mref:
+      - sfc
+    pres:
+      - msl
+      - sfc
+    ptmp:
+      - 2m
+    ptyp:
+      - sfc
+    pwtr:
+      - sfc
+    ref:
+      - m10
+      - maxm10
+    rh:
+      - 2m
+      - pw
+    rvil:
+      - sfc
+    shear:
+      - 01km
+      - 06km
+    shtfl:
+      - sfc
+    snod:
+      - sfc
+    soilm:
+      - sfc
+    soilt: &soilt_levs
+      - 0cm
+      - 1cm
+      - 4cm
+      - 10cm
+      - 30cm
+      - 60cm
+      - 1m
+      - 1.6m
+      - 3m
+    soilw: *soilt_levs
+    solar:
+      - sfc
+    ssrun:
+      - sfc
+    temp:
+      - 2ds
+      - 2m
+      - 500mb
+      - 700mb
+      - 850mb
+      - sfc
+    totp:
+      - sfc
+    trc1:
+      - sfc
+      - int
+    ulwrf:
+      - sfc
+      - top
+    uswrf:
+      - sfc
+      - top
+    vbdsf:
+      - sfc
+    vddsf:
+      - sfc
+    vig:
+      - sfc
+    vil:
+      - sfc
+    vis:
+      - sfc
+    vort:
+      - 500mb
+    vvel:
+      - 700mb
+      - mean
+    vvort:
+      - mx01
+      - mx02
+    weasd:
+      - sfc
+    wspeed:
+      - 10m
+      - 80m
+      - 160m
+      - 320m
+      - 850mb
+      - max
+      - mdn
+      - mup


### PR DESCRIPTION
These are changes necessary for comparing HRRR output to WFIP3, both the full and nested domains.  Also, 160m and 320m AGL wind plots have been added.

![image](https://github.com/NOAA-GSL/pygraf/assets/58485074/0634ff98-ec70-428b-a2ff-2af75464a843)
![image](https://github.com/NOAA-GSL/pygraf/assets/58485074/0e2b53c5-62e4-49f8-af8d-7f980ec72abb)
![image](https://github.com/NOAA-GSL/pygraf/assets/58485074/d49e2bfc-2bc2-440c-9977-9d389efeb4b6)

Sorry, the HRRR image does not have the same time as the others.