### PR TITLE
Updating version of pygraf for use on Jet Rocky8

### DIFF
--- a/pre.sh
+++ b/pre.sh
@@ -3,9 +3,7 @@
 module purge
 
 module use -a /contrib/miniconda3/modulefiles
-module load miniconda3/4.5.12
+module load miniconda3/4.12.0
 conda activate pygraf
-
-module load wgrib2/2.0.8
 
 module list


### PR DESCRIPTION
I have modified the newer version of the pygraf conda environment on Jet to link the existing libnsl library to the one named like PyNIO expects.

The same change I made in mininconda3/4.12.0 pygraf's environment could be made for the older version, but I'd prefer to use this opportunity to transition to the newer, more supportable version of miniconda.

I've run a quick test on a Jet Rocky8 frontend node, and it succeeded. I did not open the png files to see if they looked as expected. It would be super helpful if someone could check this version of pygraf to make sure it works as expected on Jet's Rocky8 frontend and compute nodes.