### PR TITLE
add run-max reflectivity and run-min press swath option for hurricanes

### DIFF
--- a/adb_graphics/default_specs.yml
+++ b/adb_graphics/default_specs.yml
@@ -587,6 +587,17 @@ cref: # Composite reflectivity
     ncl_name: REFC_P0_L{level_type}_{grid}
     title: Composite Reflectivity
     include_obs: True
+crefmax: # Comp reflectivity (max over forecast)
+  sfc:
+    accumulate: True
+    clevs: !!python/object/apply:numpy.arange [5, 76, 5]
+    cmap: NWSReflectivity
+    colors: cref_colors
+    ncl_name: REFC_P0_L200_{grid}
+    ticks: 5
+    title: Comp Reflectivity (max over forecast)
+    transform: run_max
+    unit: dBZ
 csnow: # Categorical Snow
   sfc:
     ncl_name: CSNOW_P0_L1_{grid}
@@ -1166,6 +1177,28 @@ pres:
     wind: 10m
   ua:
     ncl_name: PRES_P0_L105_{grid}
+presmin:
+  msl:
+    accumulate: True
+    annotate: True
+    clevs: !!python/object/apply:numpy.arange [860, 1001, 10]
+    cmap: NWSReflectivity
+    colors: cref_colors
+    ncl_name:
+      global: PRMSL_P0_L101_{grid}
+      globalAK: PRMSL_P0_L101_{grid}
+      globalCONUS: PRMSL_P0_L101_{grid}
+      globalNHemi: PRMSL_P0_L101_{grid}
+      globalSHemi: PRMSL_P0_L101_{grid}
+      hrrr: MSLMA_P0_L101_{grid}
+      hrrrhi: MSLMA_P0_L101_{grid}
+      hrrrcar: MSLMA_P0_L101_{grid}
+      rap: MSLMA_P0_L101_{grid}
+      rrfs: MSLET_P0_L101_{grid}
+    ticks: 0
+    transform: [conversions.pa_to_hpa, run_min]
+    unit: hPa
+#    wind: 10m
 ptmp: # Potential temperature
   2m:
     clevs: !!python/object/apply:numpy.arange [210, 350, 5]

--- a/adb_graphics/figures/maps.py
+++ b/adb_graphics/figures/maps.py
@@ -59,6 +59,7 @@ TILE_DEFS = {
     'GreatLakes': {'corners': [37, 50, -96, -70], 'stride': 10, 'length': 4},
     'HI': {'corners': [16.6, 24.6, -157.6, -157.5], 'stride': 1, 'length': 4},
     'HI-zoom': {'corners': None, 'width': 800000, 'height': 800000, 'stride': 4, 'length': 4},
+    'Hurr-Carr': {'corners': [21, 28, -96, -69], 'stride': 10, 'length': 4},
     'Juneau': {'corners': [55.741, 59.629, -140.247, -129.274], 'stride': 4, 'length': 4},
     'NW-large': {'corners': [29.5787, 52.6127, -121.666, -96.5617], 'stride': 15, 'length': 4},
     'NYC-BOS': {'corners': [39, 43.5, -77, -66.5], 'stride': 4, 'length': 4},
@@ -255,7 +256,6 @@ class Map():
         with open(fn, 'r') as f:
             data = f.readlines()
         return np.array([l.strip().split(',') for l in data], dtype=float)
-
 
 class DataMap():
     #pylint: disable=too-many-arguments

--- a/adb_graphics/figures/maps.py
+++ b/adb_graphics/figures/maps.py
@@ -59,7 +59,7 @@ TILE_DEFS = {
     'GreatLakes': {'corners': [37, 50, -96, -70], 'stride': 10, 'length': 4},
     'HI': {'corners': [16.6, 24.6, -157.6, -157.5], 'stride': 1, 'length': 4},
     'HI-zoom': {'corners': None, 'width': 800000, 'height': 800000, 'stride': 4, 'length': 4},
-    'Hurr-Carr': {'corners': [21, 28, -96, -69], 'stride': 10, 'length': 4},
+    'Hurr-Car': {'corners': [21, 28, -96, -69], 'stride': 10, 'length': 4},
     'Juneau': {'corners': [55.741, 59.629, -140.247, -129.274], 'stride': 4, 'length': 4},
     'NW-large': {'corners': [29.5787, 52.6127, -121.666, -96.5617], 'stride': 15, 'length': 4},
     'NYC-BOS': {'corners': [39, 43.5, -77, -66.5], 'stride': 4, 'length': 4},


### PR DESCRIPTION
small changes to default_specs to add options for run_min surface pressure and run_max composite reflectivity.

also added a new subregion in maps.py for "Hurr-Car" for plotting in the eastern Caribbean.

sample animated gifs of run_max reflectivity and run_min pressure below.

passed pylint test.

![ezgif com-optimize](https://github.com/NOAA-GSL/pygraf/assets/56739562/49755b21-d15b-4c5a-a06e-a0c504ddb533)
![Hurr_Idalia_min_press](https://github.com/NOAA-GSL/pygraf/assets/56739562/3b8933a1-bb38-403c-abcd-8557004bbe69)

