### PR TITLE
Skip Analysis

### DIFF
--- a/create_graphics.py
+++ b/create_graphics.py
@@ -80,16 +80,19 @@ def create_maps(cla, fhr, grib_contents, workdir, grib_contents2=None):
         args = []
         for variable, levels in cla.images[1].items():
             for level in levels:
+                if variable == 'ptyp' and fhr == 0:
+                    print(f'skipping ptyp for fhr 0')
+                else:
 
-                # Load the spec for the current variable
-                spec = cla.specs.get(variable, {}).get(level)
+                    # Load the spec for the current variable
+                    spec = cla.specs.get(variable, {}).get(level)
 
-                if not spec:
-                    msg = f'graphics: {variable} {level}'
-                    raise errors.NoGraphicsDefinitionForVariable(msg)
+                    if not spec:
+                        msg = f'graphics: {variable} {level}'
+                        raise errors.NoGraphicsDefinitionForVariable(msg)
 
-                args.append((cla, fhr, grib_contents, level, model, spec,
-                             variable, workdir, tile, grib_contents2))
+                    args.append((cla, fhr, grib_contents, level, model, spec,
+                                 variable, workdir, tile, grib_contents2))
 
         print(f'Queueing {len(args)} maps')
         with Pool(processes=cla.nprocs) as pool:


### PR DESCRIPTION
This is a small change to ignore the precip type plot at analysis.  It is needed because the wgrib2 command (that converts the wind components to Earth-relative) removes the categorical precip fields at analysis, presumably because they are all zeroes.  This causes pygraf to crash.  This change corrects that.  One caveat is that the --all_leads flag needs to be removed, since ignoring the precip type fields causes a different error at forecast hour 1.