### PR TITLE
Adding LWP and IWP to default_spec.yml

### DIFF
--- a/adb_graphics/conversions.py
+++ b/adb_graphics/conversions.py
@@ -30,7 +30,7 @@ def kg_to_g(field, **kwargs):
     ''' Conversion from kg to g '''
 
     return field * 1000.
-    
+
 def magnitude(a, b, **kwargs):
 
     ''' Return the magnitude of vector components '''

--- a/adb_graphics/conversions.py
+++ b/adb_graphics/conversions.py
@@ -25,6 +25,12 @@ def kgm2_to_in(field, **kwargs):
 
     return field * 0.03937
 
+def kg_to_g(field, **kwargs):
+
+    ''' Conversion from kg to g '''
+
+    return field * 1000.
+    
 def magnitude(a, b, **kwargs):
 
     ''' Return the magnitude of vector components '''

--- a/adb_graphics/default_specs.yml
+++ b/adb_graphics/default_specs.yml
@@ -1036,6 +1036,16 @@ icsev: # Icing Severity
       kwargs:
         level: 1000ft
         variable: icsev
+iwp: # Ice Water Path
+  sfc:
+    clevs: !!python/object/apply:numpy.arange [5, 65, 5]
+    cmap: gist_ncar
+    colors: rainbow12_colors
+    ncl_name: TCOLI_P0_L10_{grid}
+    ticks: 0
+    title: Ice Water Path
+    transform: conversions.kg_to_g
+    unit: $g/m^2$
 lcl: # Lifted condensation level
   sfc: &lcl
     clevs: !!python/object/apply:numpy.arange [0, 5000, 250]
@@ -1087,6 +1097,16 @@ lpl: # Lifted parcel level
     ncl_name: PLPL_P0_2L108_{grid}
     transform: conversions.pa_to_hpa
     unit: hPa
+lwp: # Liquid Water Path
+  sfc:
+    clevs: !!python/object/apply:numpy.arange [25, 325, 25]
+    cmap: gist_ncar
+    colors: rainbow12_colors
+    ncl_name: TCOLW_P0_L10_{grid}
+    ticks: 0
+    title: Liquid Water Path
+    transform: conversions.kg_to_g
+    unit: $g/m^2$
 ltg3: # Lightning Threat (LTG1 ... LTG2)
   sfc: 
     clevs: [0.02, 0.5, 1.0, 1.5, 2.0, 2.5, 3, 4, 5, 6, 7, 8, 10, 12]

--- a/image_lists/wfip_subset.yml
+++ b/image_lists/wfip_subset.yml
@@ -82,6 +82,8 @@ hourly:
       - mx25
     hpbl:
       - sfc
+    iwp:
+      - sfc
     lcl:
       - sfc
     lhtfl:
@@ -90,6 +92,8 @@ hourly:
       - best
       - sfc
     ltg3:
+      - sfc
+    lwp:
       - sfc
     mfrp:
       - sfc


### PR DESCRIPTION
Adding LWP and IWP to default_spec.yml, with unit as g/m2. 
This is tested on WFIP3 (WRF runs) UPP output. It should also work for HRRR.
Example plots as below:
![lwp_WFIP3-d01_sfc_f001](https://github.com/NOAA-GSL/pygraf/assets/58949533/4289526b-f755-43e5-82ce-1832710a1f40)
![iwp_WFIP3-d01_sfc_f001](https://github.com/NOAA-GSL/pygraf/assets/58949533/79cd7723-b532-47bd-a023-3a6c9d3f0758)
