### PR TITLE
initial changes to plot HFIP products.

### DIFF
--- a/adb_graphics/datahandler/gribdata.py
+++ b/adb_graphics/datahandler/gribdata.py
@@ -551,7 +551,7 @@ class fieldData(UPPData):
         '''
 
         lat, lon = self.latlons()
-        if self.model in ['global', 'obs']:
+        if self.model in ['global', 'hfip', 'obs']:
             ret = [lat[-1], lat[0], lon[0], lon[-1]]
         else:
             ret = [lat[0, 0], lat[-1, -1], lon[0, 0], lon[-1, -1]]

--- a/adb_graphics/figures/maps.py
+++ b/adb_graphics/figures/maps.py
@@ -59,6 +59,7 @@ TILE_DEFS = {
     'GreatLakes': {'corners': [37, 50, -96, -70], 'stride': 10, 'length': 4},
     'HI': {'corners': [16.6, 24.6, -157.6, -157.5], 'stride': 1, 'length': 4},
     'HI-zoom': {'corners': None, 'width': 800000, 'height': 800000, 'stride': 4, 'length': 4},
+    'HFIP': {'corners': [8.35, 51.6, 244., 336.], 'stride': 30, 'length': 4},
     'Hurr-Car': {'corners': [21, 28, -96, -69], 'stride': 10, 'length': 4},
     'Juneau': {'corners': [55.741, 59.629, -140.247, -129.274], 'stride': 4, 'length': 4},
     'NW-large': {'corners': [29.5787, 52.6127, -121.666, -96.5617], 'stride': 15, 'length': 4},
@@ -158,7 +159,7 @@ class Map():
                                 zorder=2,
                                 )
         else:
-            if self.model not in ['global'] and self.tile not in FULL_TILES:
+            if self.model not in ['global', 'hfip'] and self.tile not in FULL_TILES:
                 self.m.drawcounties(antialiased=False,
                                     color='gray',
                                     linewidth=0.1,
@@ -488,7 +489,7 @@ class DataMap():
 
         # For global lat-lon models, make 2D arrays for x and y
         # Shift the map and data if needed
-        if self.map.model in ['global']:
+        if self.map.model in ['global', 'hfip']:
             tile = self.map.tile
             if tile in ['Africa', 'Europe']:
                 vals, x = shiftgrid(180., vals, x, start=False)


### PR DESCRIPTION
HFIP runs have started and currently have a small number of output plots.  These small changes allow the "HFIP" domain to be plotted, and set the HFIP dimensions to be treated as 1D, as global plots.

Sample plots are below; additional domain and plots may need some extra changes. e.g.,
1. upper level temperatures are currently plotting as 0.5 deg K everywhere.  seems to be in the grib2 data.
2. we don't have ability to plot specific humidity yet.
3. plotting the 'full' grid plots the grids upside down.

Passed pylint.

![image](https://github.com/NOAA-GSL/pygraf/assets/56739562/a3bf1557-e8ec-438a-8939-d51e18fe677b)
![image](https://github.com/NOAA-GSL/pygraf/assets/56739562/e853a4df-c1fb-4775-8b42-2f42b80970ed)
![image](https://github.com/NOAA-GSL/pygraf/assets/56739562/0f232ee2-4468-4b54-871f-df0650a76e3e)
