### PR TITLE
changes to flux color scales and table, 3 separate color schemes

### DIFF
--- a/adb_graphics/default_specs.yml
+++ b/adb_graphics/default_specs.yml
@@ -795,10 +795,11 @@ gh: # Geopotential height
   ua:
     <<: *ua_gh
 ghtfl: # Ground Heat Flux
-  sfc: &heat_flux
-    clevs: !!python/object/apply:numpy.arange [-100, 401, 25]
-    cmap: Carbone42
-    colors: heat_flux_colors
+  sfc:
+    cmap: magma_r
+    clevs: [-200, -150, -100, -50, -25, 0, 25, 50, 100, 150, 200, 300]
+    cmap: PuOr
+    colors: heat_flux_colors_g
     ncl_name: GFLUX_P0_L1_{grid}
     ticks: 0
     title: Ground Heat Flux
@@ -1055,7 +1056,10 @@ lcl: # Lifted condensation level
     unit: m
 lhtfl: # Latent Heat Net Flux
   sfc:
-    <<: *heat_flux
+    cmap: magma_r
+    clevs: [-100, -50, -25, -10, 0, 10, 25, 50, 100, 150, 200, 250, 300, 400, 500, 750]
+    cmap: BrBG
+    colors: heat_flux_colors_l
     ncl_name: LHTFL_P0_L1_{grid}
     ticks: 0
     title: Latent Heat Net Flux
@@ -1432,7 +1436,10 @@ shear:
         level: 06km
 shtfl: # Sensible Heat Net Flux
   sfc:
-    <<: *heat_flux
+    cmap: magma_r
+    clevs: [-100, -50, -25, -10, 0, 10, 25, 50, 100, 150, 200, 250, 300, 400, 500, 750]
+    cmap: RdYlBu_r
+    colors: heat_flux_colors_s
     ncl_name: SHTFL_P0_L1_{grid}
     ticks: 0
     title: Sensible Heat Net Flux

--- a/adb_graphics/specs.py
+++ b/adb_graphics/specs.py
@@ -193,6 +193,33 @@ class VarSpec(abc.ABC):
         return np.concatenate((grays, ctable))
 
     @property
+    def heat_flux_colors_g(self) -> np.ndarray:
+
+        ''' Default color map for Latent/Sensible Heat Flux '''
+
+        colors = cm.get_cmap(self.vspec.get('cmap'), 128) \
+                          (range(15, 112, 8))
+        return colors
+
+    @property
+    def heat_flux_colors_l(self) -> np.ndarray:
+
+        ''' Default color map for Latent/Sensible Heat Flux '''
+
+        colors = cm.get_cmap(self.vspec.get('cmap'), 128) \
+                          (range(32, 129, 6))
+        return colors
+
+    @property
+    def heat_flux_colors_s(self) -> np.ndarray:
+
+        ''' Default color map for Latent/Sensible Heat Flux '''
+
+        colors = cm.get_cmap(self.vspec.get('cmap'), 128) \
+                          (range(32, 129, 6))
+        return colors
+
+    @property
     def icprb_colors(self) -> np.ndarray:
 
         ''' Default color map for Icing Probability '''


### PR DESCRIPTION
Stan B., Dave T., and Jeff D. has recommendations for new color schemes for latent/sensible/ground heat flux plots.  They wanted different scales/colors for each, so I've separated the heat_flux_colors in specs.py into three different sets, each patterned after sample supplied by Jeff.D.  I left the original in specs.py for now.

Sample plots below.

Passed pylint.

![image](https://github.com/user-attachments/assets/c35ab268-a552-41c3-85ed-39b3a30c5405)
![image](https://github.com/user-attachments/assets/32e070f2-448d-400b-8585-564bc87417d5)
![image](https://github.com/user-attachments/assets/52a4ad30-d8c0-4288-a36d-d3a9e62f108e)
