### PR TITLE
RRFS lightning with precip

### DIFF
--- a/adb_graphics/default_specs.yml
+++ b/adb_graphics/default_specs.yml
@@ -1108,8 +1108,21 @@ ltng: # Lightning
     colors: graupel_colors
     ncl_name: LTNG_P8_L10_{grid}_max1h
     ticks: 0
-    title: Max Lightning (over prv hr)
-    unit: mm
+    unit: strikes / hr
+lwtp: # Lightning with total precip
+  sfc:
+    clevs: [0.002, 0.01, 0.05, 0.1, 0.25, 0.50, 0.75, 1.0, 2.0]
+    cmap: gist_ncar
+    colors: pcp_colors
+    contours:
+      ltng_sfc:
+        colors: black
+        linewidths: 1.2
+    ncl_name: APCP_P8_L1_{grid}_acc1h
+    ticks: 0
+    title: 1 hr Precip & Lightning
+    transform: conversions.kgm2_to_in
+    unit: in
 mfrp: # Fire radiative power
   sfc:
     clevs: [0, 10, 25, 50, 100, 250]

--- a/adb_graphics/figures/maps.py
+++ b/adb_graphics/figures/maps.py
@@ -43,7 +43,7 @@ TILE_DEFS = {
     'Africa': {'corners': [-40, 40, -40, 60], 'stride': 7, 'length': 5},
     'AKZoom': {'corners': [52, 73, -162, -132], 'stride': 4, 'length': 5},
     'AKZoom2': {'corners': [37.9, 80.8, 180, -105.7], 'stride': 8, 'length': 5},
-    'AKRange': {'corners': [59.722, 65.022, -153.583, -144.289], 'stride': 4, 'length': 4},
+    'AKRange': {'corners': [62.0, 67.0, -152.0, -143.0], 'stride': 4, 'length': 4},
     'Anchorage': {'corners': [58.59, 62.776, -152.749, -146.218], 'stride': 4, 'length': 4},
     'ATL': {'corners': [31.2, 35.8, -87.4, -79.8], 'stride': 4, 'length': 4},
     'Beijing': {'corners': [25, 53, 102, 133], 'stride': 3, 'length': 5},

--- a/image_lists/rrfs_subset.yml
+++ b/image_lists/rrfs_subset.yml
@@ -101,6 +101,8 @@ hourly:
       - sfc
     ltng:
       - sfc
+    lwtp:
+      - sfc
     mref:
       - sfc
     pres:


### PR DESCRIPTION
Adding a new plot, which is an amalgamation of a new field (lightning) and 1h total precip.

Here's an example:

![image](https://github.com/user-attachments/assets/19e19419-a1a9-4693-8f2b-be6b8c3d52c1)
