### PR TITLE
fix for special accumulation case where MASSDEN 0h field ends in '_1'

### DIFF
--- a/adb_graphics/datahandler/gribfile.py
+++ b/adb_graphics/datahandler/gribfile.py
@@ -104,7 +104,7 @@ class GribFiles():
                 # MASSDEN is a special case when ending in "avg_1'"
                 if var.split('_')[0] == 'MASSDEN' and var.split('_')[-2] == 'avg':
                     print(f'Special change to MASSDEN avg_1 name to avg1h_1')
-                    ret[var] = var.replace('avg','avg1h')
+                    ret[var] = var.replace('avg', 'avg1h')
             else:
                 # Only rename these variables at late hours
                 odd_variables = [

--- a/adb_graphics/datahandler/gribfile.py
+++ b/adb_graphics/datahandler/gribfile.py
@@ -101,6 +101,10 @@ class GribFiles():
                 if suffix in special_suffixes and needs_renaming:
                     new_suffix = f'{suffix}1h' if 'global' not in self.model else f'{suffix}6h'
                     ret[var] = var.replace(suffix, new_suffix)
+                # MASSDEN is a special case when ending in "avg_1'"
+                if var.split('_')[0] == 'MASSDEN' and var.split('_')[-2] == 'avg':
+                    print(f'Special change to MASSDEN avg_1 name to avg1h_1')
+                    ret[var] = var.replace('avg','avg1h')
             else:
                 # Only rename these variables at late hours
                 odd_variables = [


### PR DESCRIPTION
The MASSDEN field (measuring dust) has two variables, one for coarse and one for fine. For the initial hour, one field ends with '_avg' and one with '_avg_1'. For later hours they end in '_avg1h' and '_avg1h_1'.

The pygraf code recognizes the '_avg' and renames the field as needed, but doesn't recognize the '_avg_1' field as needing to be renamed. The error causes the graphics code to completely crash on hour=001.

This change treats the initlal-hour '_avg_1' field separately from the other code logic, and does the necessary renaming.  

Tested in the RRFS_B realtime runs for twelve hours, seems to work as desired.

Passed pylint. Will do pytest on PR submission. 