### PR TITLE
Pass specs file name to fieldData class

### DIFF
--- a/adb_graphics/figure_builders.py
+++ b/adb_graphics/figure_builders.py
@@ -117,6 +117,7 @@ def parallel_maps(cla, fhr, ds, level, model, spec, variable, workdir,
             member=mem,
             model=model,
             short_name=variable,
+            config=cla.specs['file']
             )
 
         try:
@@ -135,6 +136,7 @@ def parallel_maps(cla, fhr, ds, level, model, spec, variable, workdir,
                 member=mem,
                 model=model,
                 short_name=variable,
+                config=cla.specs['file']
                 )
 
             try:

--- a/adb_graphics/utils.py
+++ b/adb_graphics/utils.py
@@ -287,6 +287,8 @@ def load_specs(arg):
     with open(spec_file, 'r') as fn:
         specs = yaml.load(fn, Loader=yaml.Loader)
 
+    specs['file'] = spec_file
+
     return specs
 
 def old_enough(age, file_path):


### PR DESCRIPTION
The `default_specs.yml` file controls which fields are extracted from the UPP GRIB2 output for plotting as well as the plotting specifications. When using a custom version of `default_specs.yml` with the `--specs` option, information about which UPP fields to extract are not passed to the `adb_graphics.datahandler.gribdata.fieldData` class as expected. Instead, the default values are always used.

This PR addresses this bug by making a few, minor changes to pass the user-defined specs file to `adb_graphics.datahandler.gribdata.fieldData`.

Test: Offline using UPP output with fields following a mix of HRRR and RRFS naming conventions. Updated code successfully leveraged a user-defined specs file so that the correct fields were plotted.