### PR TITLE
remove accumulated snow from Caribbean image lists

### DIFF
--- a/image_lists/hrrrcar_subset.yml
+++ b/image_lists/hrrrcar_subset.yml
@@ -1,8 +1,6 @@
 hourly:
   model: hrrrcar
   variables:
-    1hsnw:
-      - sfc
     1ref:
       - 1000m
     acfrozr:
@@ -12,8 +10,6 @@ hourly:
     acpcp:
       - sfc
     acsnod:
-      - sfc
-    acsnw:
       - sfc
     cape:
       - mu


### PR DESCRIPTION
pygraf was crashing on HRRR_CAR runs because the logic in default_specs.yml to provide the ncl_name for two accumulated snow fields, 1h snow (10:1) and accum snow (10:1), does not include an option for HRRR_CAR.

The otopions were to add the case for HRRR_CAR in the logic for those two fields, or remove them from the image_list.  Talking with David Dowell, he seemed comfortable that they won't be needed over the Caribbean, so removed from image_lists/hrrrcar_subset.yml.

This change has been in the real time Caribbean runs as a hot fix and seems to have solved the issue.

Passed pylint.