### PR TITLE
new_ua_temp_colormaps

### DIFF
--- a/adb_graphics/default_specs.yml
+++ b/adb_graphics/default_specs.yml
@@ -1674,7 +1674,7 @@ temp: # Temperature
     unit: F
     wind: 10m
   500mb: &ua_temp
-    clevs: !!python/object/apply:numpy.arange [-70, 10, 2.5]
+    clevs: !!python/object/apply:numpy.arange [-40, 40, 2.5]
     cmap: jet
     colors: t_colors
     contours:
@@ -1697,7 +1697,6 @@ temp: # Temperature
     wind: True
   700mb:
     <<: *ua_temp
-    clevs: !!python/object/apply:numpy.arange [-40, 40, 2.5]
     contours:
       pres_sfc:
         colors: 'k'
@@ -1711,7 +1710,6 @@ temp: # Temperature
         levels: [0, 700]
   850mb:
     <<: *ua_temp
-    clevs: !!python/object/apply:numpy.arange [-40, 40, 2.5]
     contours:
       pres_sfc:
         colors: 'k'
@@ -1723,7 +1721,6 @@ temp: # Temperature
         levels: [0, 850]
   925mb:
     <<: *ua_temp
-    clevs: !!python/object/apply:numpy.arange [-40, 40, 2.5]
     contours:
       pres_sfc:
         colors: 'k'

--- a/adb_graphics/default_specs.yml
+++ b/adb_graphics/default_specs.yml
@@ -1676,7 +1676,7 @@ temp: # Temperature
   500mb: &ua_temp
     clevs: !!python/object/apply:numpy.arange [-40, 40, 2.5]
     cmap: jet
-    colors: t_colors
+    colors: ua_temp_colors
     contours:
       pres_sfc:
         levels: [0, 500]

--- a/adb_graphics/specs.py
+++ b/adb_graphics/specs.py
@@ -476,8 +476,12 @@ class VarSpec(abc.ABC):
 
         ''' Default color map for Upper-Air Temperature '''
 
-        ncolors = len(self.clevs)
-        return cm.get_cmap(self.vspec.get('cmap', 'jet'), ncolors)(range(ncolors))
+        grays = cm.get_cmap('Greys', 27)(range(17, 1, -2))
+        purples = cm.get_cmap('Purples', 27)(range(17, 1, -2))
+        ncar = cm.get_cmap(self.vspec.get('cmap'), 128) \
+                          ([30, 34, 36, 40, 45, 55, 60, 65, 70, \
+                          75, 80, 85, 90, 95, 100, 115])
+        return np.concatenate((grays, purples, ncar))
 
     @property
     def tsfc_colors(self) -> np.ndarray:

--- a/adb_graphics/specs.py
+++ b/adb_graphics/specs.py
@@ -474,14 +474,10 @@ class VarSpec(abc.ABC):
     @property
     def t_colors(self) -> np.ndarray:
 
-        ''' Default color map for Upper-Air Temperature '''
+        ''' Default color map for Potential Temperature '''
 
-        grays = cm.get_cmap('Greys', 27)(range(17, 1, -2))
-        purples = cm.get_cmap('Purples', 27)(range(17, 1, -2))
-        ncar = cm.get_cmap(self.vspec.get('cmap'), 128) \
-                          ([30, 34, 36, 40, 45, 55, 60, 65, 70, \
-                          75, 80, 85, 90, 95, 100, 115])
-        return np.concatenate((grays, purples, ncar))
+        ncolors = len(self.clevs)
+        return cm.get_cmap(self.vspec.get('cmap', 'jet'), ncolors)(range(ncolors))
 
     @property
     def tsfc_colors(self) -> np.ndarray:
@@ -502,6 +498,18 @@ class VarSpec(abc.ABC):
         ctable = ctables.colortables.get_colortable(self.vspec.get('cmap')) \
                     (range(54, 157, 6))
         return ctable
+
+    @property
+    def ua_temp_colors(self) -> np.ndarray:
+
+        ''' Default color map for Upper-Air Temperature '''
+
+        grays = cm.get_cmap('Greys', 27)(range(17, 1, -2))
+        purples = cm.get_cmap('Purples', 27)(range(17, 1, -2))
+        ncar = cm.get_cmap(self.vspec.get('cmap'), 128) \
+                          ([30, 34, 36, 40, 45, 55, 60, 65, 70, \
+                          75, 80, 85, 90, 95, 100, 115])
+        return np.concatenate((grays, purples, ncar))
 
     @property
     def vis_colors(self) -> np.ndarray:


### PR DESCRIPTION
These are some requested changes in the 925mb, 850mb, 700mb, and 500mb temperature contours, to clearly delineate the 0 deg line and provide more clarity in the -5 to +5 C range.  The 500mb scale was changed to match the scales at the other levels.

![image](https://github.com/user-attachments/assets/c9231fc5-d926-43ca-a7ac-ffcdeec69e51)
![image](https://github.com/user-attachments/assets/b02e3744-ad46-4109-9463-416df3fb183c)
