### PR TITLE
change skin temperature title from "sfc" to "Skin" Temperature

### DIFF
--- a/adb_graphics/default_specs.yml
+++ b/adb_graphics/default_specs.yml
@@ -1736,6 +1736,7 @@ temp: # Temperature
   sfc:
     <<: *sfc_temp
     ncl_name: TMP_P0_L1_{grid}
+    title: Skin Temperature
     wind: False
   ua:
     <<: *ua_temp


### PR DESCRIPTION
A simple one-line code addition in default_spec.yml, to change the title for sfc temperature to "Skin Temperature".

This was requested by Stan Benjamin, who noted that using the name sfc temperature can be ambiguous.  The title was a default value since none was given for that field. Added a title line in default_specs.yml.

Before and after images attached. Stan approved the change.

Passed pylint.

![image](https://github.com/user-attachments/assets/893bd5b9-d206-4bf6-8121-5be7e45d4dc9)
![image](https://github.com/user-attachments/assets/c16c9678-2a69-4bdc-9a05-a2e0168df774)
