### PR TITLE
Adding plots of snow-to-liquid ratio (SLR)

### DIFF
--- a/adb_graphics/conversions.py
+++ b/adb_graphics/conversions.py
@@ -101,3 +101,9 @@ def weasd_to_1hsnw(field, **kwargs):
     ''' Conversion from snow wter equiv to snow (10:1 ratio) '''
 
     return field * 10.
+
+def sden_to_slr(field, **kwargs):
+
+    ''' Convert snow density to snow-liquid ratio '''
+
+    return 1000. / field

--- a/adb_graphics/conversions.py
+++ b/adb_graphics/conversions.py
@@ -104,6 +104,6 @@ def weasd_to_1hsnw(field, **kwargs):
 
 def sden_to_slr(field, **kwargs):
 
-    ''' Convert snow density to snow-liquid ratio '''
+    ''' Convert snow density (kg m-3) to snow-liquid ratio '''
 
     return 1000. / field

--- a/adb_graphics/default_specs.yml
+++ b/adb_graphics/default_specs.yml
@@ -2013,8 +2013,7 @@ snoliqr: # Snow-liquid ratio (from U. Utah diagnostic in UPP)
     clevs: [6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28]
     cmap: gist_ncar
     colors: snow_colors
-    ncl_name:
-      rrfs: SDEN_P0_L1_{grid}
+    ncl_name: SDEN_P0_L1_{grid}
     ticks: 0
     title: Instantaneous Snow-Liquid Ratio (U. Utah Method)
     transform: conversions.sden_to_slr

--- a/adb_graphics/default_specs.yml
+++ b/adb_graphics/default_specs.yml
@@ -2011,6 +2011,17 @@ weasd: # Water equivalent of accumulated snow depth
     title: Snow Water Equivalent
     transform: conversions.kgm2_to_in
     unit: in
+snoliqr: # Snow-liquid ratio (from U. Utah diagnostic in UPP)
+  sfc:
+    clevs: [6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28]
+    cmap: gist_ncar
+    colors: snow_colors
+    ncl_name:
+      rrfs: SDEN_P0_L1_{grid}
+    ticks: 0
+    title: Instantaneous Snow-Liquid Ratio (U. Utah Method)
+    transform: conversions.sden_to_slr
+    print_units: false
 windmax:
   10m:
     accumulate: True

--- a/image_lists/hrrr_subset.yml
+++ b/image_lists/hrrr_subset.yml
@@ -15,6 +15,8 @@ hourly:
       - sfc
     acsnw:
       - sfc
+    snoliqr:
+      - sfc
     cape:
       - mu
       - mul

--- a/image_lists/rrfs_subset.yml
+++ b/image_lists/rrfs_subset.yml
@@ -15,8 +15,6 @@ hourly:
       - sfc
     acsnw:
       - sfc
-    snoliqr:
-      - sfc
     cape:
       - mu
       - mul

--- a/image_lists/rrfs_subset.yml
+++ b/image_lists/rrfs_subset.yml
@@ -15,6 +15,8 @@ hourly:
       - sfc
     acsnw:
       - sfc
+    snoliqr:
+      - sfc
     cape:
       - mu
       - mul


### PR DESCRIPTION
This PR adds functionality to produce plots of snow-to-liquid ratio (SLR).  The SLR field is obtained from the GRIB2 "SDEN" field (snow density, in kg m-3) using a simple conversion.  Testing of this functionality has been sucessful for a RRFS-MPAS case on Jet (see figure below).

<img width="711" alt="snoliqr" src="https://github.com/user-attachments/assets/b61595e5-534a-4d25-acc5-9a2594ecfd50" />




For reference, the "SDEN" code in UPP uses a diagnostic from the University of Utah.  GRIB2 output of "SDEN" was added to GSL's RRFS-MPAS runs via this merged PR in UPP: https://github.com/NOAA-EMC/UPP/commit/d1f616733919c183a796e9c4d8207c712c62b095.