### PR TITLE
global_chem_changes

### DIFF
--- a/adb_graphics/default_specs.yml
+++ b/adb_graphics/default_specs.yml
@@ -282,7 +282,7 @@ aodtot: # Total AOD
     title: Total Aerosol Optical Depth
 bc: # Black Carbon
   sfc: &bcsfc
-    clevs: [0.05, 0.1, 0.15, 0.2, 0.5, 1, 2, 3, 4, 5, 7, 10, 15, 20]
+    clevs: [0.05, 0.1, 0.2, 0.5, 1, 2, 3, 4, 5, 7, 10, 15, 20, 30]
     cmap: jet
     colors: aod_colors
     ncl_name: PMTF_P48_L105_{grid}_A62014
@@ -532,7 +532,7 @@ colfd: # Column Fine Dust
 coloc: # Column Organic Carbon
   sfc:
     <<: *col
-    clevs: [0.05, 0.1, 0.2, 0.5, 1, 2, 3, 4, 5, 7.5, 10, 20, 30, 40]
+    clevs: [0.5, 1,  5, 10, 20, 30, 40, 50, 80, 100, 120, 150, 200, 250]
     ncl_name: COLMD_P48_L10_{grid}_A62010
     title: Column Organic Carbon
 colpm10: # Column PM10
@@ -627,9 +627,42 @@ dewp: # Dew point temperature
     transform: conversions.k_to_f
     unit: F
     wind: 10m
+dlwrf: # Downward Longwave Radiation Flux
+  sfc: &radiation_flux
+    clevs: !!python/object/apply:numpy.arange [200, 501, 12]
+    cmap: gist_ncar
+    colors: radiation_colors
+    ncl_name: DLWRF_P0_L1_{grid}
+    ticks: -2
+    title: Downward Longwave Radiation Flux, Surface
+    unit: W/m$^{2}$
+  top: # Nominal top of atmosphere
+    clevs: !!python/object/apply:numpy.arange [80, 341, 2]
+    cmap: ir_rgbv_r
+    colors: radiation_mix_colors
+    ncl_name: DLWRF_P0_L8_{grid}
+    ticks: 20
+    title: Incoming Longwave Radiation Flux, TOA
+    unit: W/m$^{2}$
+dswrf: # Downward Shortwave Radiation Flux
+  sfc:
+    <<: *radiation_flux
+    clevs: [0, 50, 100, 150, 200, 250, 300, 400, 500, 600, 700, 800, 900, 1000]
+    colors: rainbow12_colors
+    ncl_name: DSWRF_P0_L1_{grid}
+    ticks: 0
+    title: Downward Shortwave Radiation Flux, Surface
+  top: # Nominal top of atmosphere
+    <<: *radiation_flux
+    clevs: !!python/object/apply:numpy.arange [50, 851, 10]
+    cmap: Greys_r
+    colors: radiation_bw_colors
+    ncl_name: DSWRF_P0_L8_{grid}
+    ticks: 40
+    title: Incoming Shortwave Radiation Flux, TOA
 fd: # Fine dust, global chem
   sfc:
-    clevs: [0.05, 0.1, 0.15, 0.2, 0.5, 1, 2, 3, 4, 5, 7, 10, 15, 20]
+    clevs: [1, 2, 4, 6, 8, 12, 16, 20, 25, 30, 40, 60, 100, 200]
     cmap: jet
     colors: aod_colors
     ncl_name: PMTF_P48_L1_{grid}_A62001
@@ -1067,7 +1100,7 @@ lcl: # Lifted condensation level
     <<: *lcl
     unit: m
 lhtfl: # Latent Heat Net Flux
-  sfc:
+  sfc: &lhtflsfc
     cmap: magma_r
     clevs: [-100, -50, -25, -10, 0, 10, 25, 50, 100, 150, 200, 250, 300, 400, 500, 750]
     cmap: BrBG
@@ -1076,6 +1109,11 @@ lhtfl: # Latent Heat Net Flux
     ticks: 0
     title: Latent Heat Net Flux
     unit: W/m$^{2}$
+lhtflavg:
+  sfc:
+    <<: *lhtflsfc
+    ncl_name: LHTFL_P8_L1_{grid}_avg6h
+    title: Avg Latent Heat Net Flux
 li: # Lifted Index
   best: &lifted_index
     clevs: !!python/object/apply:numpy.arange [-15, 16]
@@ -1151,7 +1189,7 @@ mref: # Maximum reflectivity for past hour at 1 km AGL
     title: Max 1km agl Reflectivity (over prev hr)
 oc: # Organic Carbon
   sfc: &ocsfc
-    clevs: [0.05, 0.1, 0.15, 0.2, 0.5, 1, 2, 3, 4, 5, 7, 10, 15, 20]
+    clevs: [0.05, 0.1, 0.5, 1, 2, 3, 5, 7, 10, 15, 20, 30, 50, 100]
     cmap: jet
     colors: aod_colors
     ncl_name: PMTF_P48_L105_{grid}_A62014
@@ -1178,7 +1216,7 @@ oc2: # Organic Carbon 2
     transform: []
 PM10: # PM10, global chem
   sfc: &pmsfc
-    clevs: [0.05, 0.1, 0.15, 0.2, 0.5, 1, 2, 3, 4, 5, 7, 10, 15, 20]
+    clevs: [0.5, 1, 2, 5, 10, 20, 30, 50, 70, 100, 150, 200, 500, 1000]
     cmap: jet
     colors: aod_colors
     ncl_name: PMTC_P48_L1_{grid}_A62000
@@ -1435,7 +1473,7 @@ rwmr: # Rain Mixing Ratio
       prs: RWMR_P0_L100_{grid}
 seasalt: # Fine dust, global chem
   sfc:
-    clevs: [0.05, 0.1, 0.15, 0.2, 0.5, 1, 2, 3, 4, 5, 7, 10, 15, 20]
+    clevs: [0.05, 0.1, 0.5, 1, 2, 3, 5, 10, 15, 20, 30, 40, 50, 100]
     cmap: jet
     colors: aod_colors
     ncl_name: PMTF_P48_L1_{grid}_A62008
@@ -1470,7 +1508,7 @@ shear:
         split: True
         level: 06km
 shtfl: # Sensible Heat Net Flux
-  sfc:
+  sfc: &shtflsfc
     cmap: magma_r
     clevs: [-100, -50, -25, -10, 0, 10, 25, 50, 100, 150, 200, 250, 300, 400, 500, 750]
     cmap: RdYlBu_r
@@ -1479,6 +1517,11 @@ shtfl: # Sensible Heat Net Flux
     ticks: 0
     title: Sensible Heat Net Flux
     unit: W/m$^{2}$
+shtflavg:
+  sfc:
+    <<: *shtflsfc
+    ncl_name: SHTFL_P8_L1_{grid}_avg6h
+    title: Avg Sensible Heat Net Flux
 sipd: # Supercooled Large Droplet Icing
   # levels chosen are arbitrary based on initial plot samples
   # additional levels may be requested in the future.
@@ -1640,7 +1683,7 @@ ssrun: # Storm Surface Runoff
     unit: in
 sulf: # Sulfate, global chem
   sfc:
-    clevs: [0.05, 0.1, 0.15, 0.2, 0.5, 1, 2, 3, 4, 5, 7, 10, 15, 20]
+    clevs: [0.05, 0.1, 0.2, 0.5, 1, 2, 3, 5, 10, 15, 20, 30 ,40 ,50]
     cmap: jet
     colors: aod_colors
     ncl_name: PMTF_P48_L105_{grid}_A62006
@@ -1851,7 +1894,8 @@ u:
   ua:
     <<: *ua_uwind
 ulwrf: # Upward Longwave Radiation Flux
-  sfc: &radiation_flux
+  sfc:
+    <<: *radiation_flux
     clevs: !!python/object/apply:numpy.arange [350, 601, 10]
     cmap: gist_ncar
     colors: radiation_colors

--- a/image_lists/global.yml
+++ b/image_lists/global.yml
@@ -25,6 +25,10 @@ hourly:
       - sfc
     dewp:
       - 2m
+    dlwrf:
+      - sfc
+    dswrf:
+      - sfc
     gh:
       - 500mb
     gust:
@@ -36,6 +40,8 @@ hourly:
       - sfc
     lhtfl:
       - sfc
+    lhtflavg:
+      - sfc
     pres:
       - msl
     pwtr:
@@ -45,6 +51,8 @@ hourly:
       - 850mb
       - mean
     shtfl:
+      - sfc
+    shtflavg:
       - sfc
     snod:
       - sfc

--- a/image_lists/globalAK.yml
+++ b/image_lists/globalAK.yml
@@ -3,6 +3,8 @@ hourly:
   variables:
     1ref:
       - 1000m
+    acpcp:
+      - sfc
     cape:
       - mu
       - mul
@@ -23,6 +25,10 @@ hourly:
       - sfc
     dewp:
       - 2m
+    dlwrf:
+      - sfc
+    dswrf:
+      - sfc
     gh:
       - 500mb
     gust:
@@ -34,6 +40,8 @@ hourly:
       - sfc
     lhtfl:
       - sfc
+    lhtflavg:
+      - sfc
     pres:
       - msl
     pwtr:
@@ -43,6 +51,8 @@ hourly:
       - 850mb
       - mean
     shtfl:
+      - sfc
+    shtflavg:
       - sfc
     snod:
       - sfc

--- a/image_lists/globalCONUS.yml
+++ b/image_lists/globalCONUS.yml
@@ -3,6 +3,8 @@ hourly:
   variables:
     1ref:
       - 1000m
+    acpcp:
+      - sfc
     cape:
       - mu
       - mul
@@ -23,6 +25,10 @@ hourly:
       - sfc
     dewp:
       - 2m
+    dlwrf:
+      - sfc
+    dswrf:
+      - sfc
     gh:
       - 500mb
     gust:
@@ -34,6 +40,8 @@ hourly:
       - sfc
     lhtfl:
       - sfc
+    lhtflavg:
+      - sfc
     pres:
       - msl
     pwtr:
@@ -43,6 +51,8 @@ hourly:
       - 850mb
       - mean
     shtfl:
+      - sfc
+    shtflavg:
       - sfc
     snod:
       - sfc

--- a/image_lists/globalNHemi.yml
+++ b/image_lists/globalNHemi.yml
@@ -3,6 +3,8 @@ hourly:
   variables:
     1ref:
       - 1000m
+    acpcp:
+      - sfc
     cape:
       - mu
       - mul
@@ -23,6 +25,10 @@ hourly:
       - sfc
     dewp:
       - 2m
+    dlwrf:
+      - sfc
+    dswrf:
+      - sfc
     gh:
       - 500mb
     gust:
@@ -34,6 +40,8 @@ hourly:
       - sfc
     lhtfl:
       - sfc
+    lhtflavg:
+      - sfc
     pres:
       - msl
     pwtr:
@@ -43,6 +51,8 @@ hourly:
       - 850mb
       - mean
     shtfl:
+      - sfc
+    shtflavg:
       - sfc
     snod:
       - sfc

--- a/image_lists/global_chem.yml
+++ b/image_lists/global_chem.yml
@@ -57,7 +57,13 @@ hourly:
       - sfc
     cref:
       - sfc
+    ctop:
+      - ua
+    dewp:
+      - 2m
     fd:
+      - sfc
+    flru:
       - sfc
     gust:
       - 10m
@@ -78,8 +84,14 @@ hourly:
       - sfc
     PM25:
       - sfc
+    pres:
+      - msl
+    ptyp:
+      - sfc
     pwtr:
       - sfc
+    rh:
+      - 850mb
     seasalt:
       - sfc
     shtfl:
@@ -92,10 +104,24 @@ hourly:
     soilw: *soilt_levs
     sulf:
       - sfc
+    temp:
+      - 2ds
+      - 2m
+      - 500mb
+      - 700mb
+      - 850mb
+      - 925mb
+      - sfc
+    totp6h:
+      - sfc
+    totp:
+      - sfc
     ulwrf:
       - sfc
+      - top
     uswrf:
       - sfc
+      - top
     vis:
       - sfc
     vort:
@@ -104,3 +130,8 @@ hourly:
       - 700mb
     weasd:
       - sfc
+    wspeed:
+      - 10m
+      - 80m
+      - 250mb
+      - 850mb


### PR DESCRIPTION
Contour level changes in chem variables.  Added dlwrf and dswrf (though not currently in grib2 files), added new products lhtflavg and shtflavg (to distinguish them from the instantaneous lhtfl and shtfl).  global_chem.yml has added ctop, dewp, flru, pres (msl), ptyp, and others.  Only a few can currently plot but will leave the others in the presumption that these variables are intended to be added.

New product examples:

![image](https://github.com/user-attachments/assets/ceebf1c1-ade3-43bc-983e-5ea3eb25e642)

![image](https://github.com/user-attachments/assets/0cac7fad-95aa-45da-b799-274e3467a412)
