### PR TITLE
Adding "regional_mpas" as a model configuration

### DIFF
--- a/adb_graphics/datahandler/gribdata.py
+++ b/adb_graphics/datahandler/gribdata.py
@@ -341,7 +341,7 @@ class UPPData(specs.VarSpec):
         entire atmosphere in HRRR, while 200 is used in RRFS. '''
 
         if self.filetype == 'prs':
-            if self.model == 'rrfs':
+            if self.model == 'rrfs' or self.model == 'regional_mpas':
                 return 200
             return 10
         return 105

--- a/adb_graphics/default_specs.yml
+++ b/adb_graphics/default_specs.yml
@@ -87,6 +87,7 @@
       hrrrhi: WEASD_P8_L1_{grid}_acc1h
       rap: WEASD_P8_L1_{grid}_acc1h
       rrfs: TSNOWP_P8_L1_{grid}_acc1h
+      regional_mpas: WEASD_P8_L1_{grid}_acc1h
     ticks: 0
     title: 1 hr Accumulated Snow Using 10:1 Ratio
     transform: [conversions.kgm2_to_in, conversions.weasd_to_1hsnw]
@@ -237,6 +238,7 @@ acsnw: # Run Total Accumulated Snow Using 10:1 Ratio
       hrrrhi: WEASD_P8_L1_{grid}_acc
       rap: WEASD_P8_L1_{grid}_acc
       rrfs: TSNOWP_P8_L1_{grid}_acc
+      regional_mpas: WEASD_P8_L1_{grid}_acc
     ticks: 0
     title: Run-Total Accumulated Snow Using 10:1 Ratio
     transform: [conversions.kgm2_to_in, conversions.weasd_to_1hsnw]
@@ -408,7 +410,8 @@ ceil: # Ceiling
 ceilexp: # Ceiling - experimental
   ua:
     <<: *ceil
-    ncl_name: CEIL_P0_L215_{grid}
+    ncl_name: 
+      regional_mpas: CEIL_P0_L215_{grid}
     title: Ceiling (exp)
 ceilexp2: # Ceiling - experimental no.2
   ua:
@@ -419,6 +422,7 @@ ceilexp2: # Ceiling - experimental no.2
       hrrrcar: HGT_P0_L2_{grid}
       rap: HGT_P0_L2_{grid}
       rrfs: CEIL_P0_L2_{grid}
+      regional_mpas: CEIL_P0_L2_{grid}
     title: Ceiling (exp-2)
 cfrzr: # Categorical Freezing Rain
   sfc:
@@ -701,6 +705,7 @@ echotop: # Echo Top
       hrrrcar: RETOP_P0_L3_{grid}
       rap: RETOP_P0_L3_{grid}
       rrfs: RETOP_P0_L200_{grid}
+      regional_mpas: RETOP_P0_L3_{grid}
     ticks: 0
     title: Echo Top
     transform: conversions.m_to_kft
@@ -882,6 +887,7 @@ hailcast: # Max 1h Hail diameter
       hrrrcar: HAIL_P8_L1_{grid}_max1h
       rap: HAIL_P8_L1_{grid}_max1h
       rrfs: HAIL_P8_L1_{grid}_max1h
+      regional_mpas: HAIL_P8_L1_{grid}_max1h
     title: Max 6h Hail Diameter at Sfc from HAILCAST
 hlcy: # Helicity
   in16: &hlcy # Hourly updraft helicity over 1-6 km layer
@@ -1254,6 +1260,7 @@ pres:
       hrrrcar: MSLMA_P0_L101_{grid}
       rap: MSLMA_P0_L101_{grid}
       rrfs: MSLET_P0_L101_{grid}
+      regional_mpas: MSLMA_P0_L101_{grid}
     ticks: 0
     transform: conversions.pa_to_hpa
     unit: hPa
@@ -1278,6 +1285,7 @@ presmin:
       hrrrcar: MSLMA_P0_L101_{grid}
       rap: MSLMA_P0_L101_{grid}
       rrfs: MSLET_P0_L101_{grid}
+      regional_mpas: MSLMA_P0_L101_{grid}
     ticks: 0
     transform: [conversions.pa_to_hpa, run_min]
     unit: hPa
@@ -1463,6 +1471,7 @@ rvil: # Radar-derived Vertically Integrated Liquid
       hrrrcar: VIL_P0_L{level_type}_{grid}
       rap: VIL_P0_L{level_type}_{grid}
       rrfs: VIL_P0_L200_{grid}
+      regional_mpas: VIL_P0_L{level_type}_{grid}
     ticks: 0
     title: Radar-derived Vertically Integrated Liquid
     unit: kg/m$^{2}$
@@ -1582,6 +1591,7 @@ soilm: # Soil Moisture Availability
       hrrrcar: MSTAV_P0_L106_{grid}
       rap: MSTAV_P0_L106_{grid}
       rrfs: MSTAV_P0_L106_{grid}
+      regional_mpas: MSTAV_P0_L106_{grid}
     ticks: 0
     title: Soil Moisture Availability
     unit: "%"
@@ -1824,10 +1834,11 @@ trc1:
     clevs: [1, 4, 7, 11, 15, 20, 25, 30, 40, 50, 75, 150, 250, 500]
     colors: smoke_colors
     ncl_name:
-      hrrr:  COLMD_P0_L200_{grid}
-      hrrrcar:  COLMD_P0_L200_{grid}
-      rap:  COLMD_P0_L200_{grid}
+      hrrr: COLMD_P0_L200_{grid}
+      hrrrcar: COLMD_P0_L200_{grid}
+      rap: COLMD_P0_L200_{grid}
       rrfs: COLMD_P48_L200_{grid}_A62010
+      regional_mpas: COLMD_P0_L200_{grid}
     plot_airports: False
     ticks: 0
     title: Vertically Integrated Smoke
@@ -1856,6 +1867,7 @@ trc1:
       hrrrcar: MASSDEN_P0_L103_{grid}
       rap: MASSDEN_P0_L103_{grid}
       rrfs: MASSDEN_P48_L103_{grid}_A62010
+      regional_mpas: MASSDEN_P0_L103_{grid}
     plot_airports: False
     title: Near-Surface Smoke
     transform: conversions.to_micrograms_per_m3

--- a/image_lists/regional_mpas_subset.yml
+++ b/image_lists/regional_mpas_subset.yml
@@ -1,0 +1,182 @@
+hourly:
+  model: regional_mpas
+  variables:
+    1ref:
+      - 1000m
+    acfrozr:
+      - sfc
+    acfrzr:
+      - sfc
+    acpcp:
+      - sfc
+    acsnod:
+      - sfc
+    snoliqr:
+      - sfc
+    cape:
+      - mu
+      - mul
+      - mx90mb
+      - sfc
+    cin:
+      - sfc
+    ceil:
+      - ua
+    ceilexp:
+      - ua
+    ceilexp2:
+      - ua
+    cloudcover:
+      - bndylay
+      - high
+      - low
+      - mid
+      - total
+    cpofp:
+      - sfc
+    cref:
+      - sfc
+    ctop:
+      - ua
+    dewp:
+      - 2m
+    echotop:
+      - sfc
+    flru:
+      - sfc
+    G113bt:
+      - sat
+    G114bt:
+      - sat
+    G123bt:
+      - sat
+    G124bt:
+      - sat
+    gust:
+      - 10m
+    hail:
+      - max
+      - maxsfc
+    hailcast:
+      - maxsfc
+    hlcy:
+      - in25
+      - mn02
+      - mn03
+      - mn25
+      - mx02
+      - mx03
+      - mx25
+      - sr01
+      - sr03
+    hlcytot:
+      - mn02
+      - mn03
+      - mn25
+      - mx02
+      - mx03
+      - mx25
+    hpbl:
+      - sfc
+    lcl:
+      - sfc
+    lhtfl:
+      - sfc
+    li:
+      - best
+      - sfc
+    ltg3:
+      - sfc
+    mfrp:
+      - sfc
+    mref:
+      - sfc
+    pres:
+      - msl
+      - sfc
+    ptmp:
+      - 2m
+    ptyp:
+      - sfc
+    pwtr:
+      - sfc
+    ref:
+      - m10
+      - maxm10
+    rh:
+      - 2m
+      - 850mb
+      - mean
+      - pw
+    rvil:
+      - sfc
+    shear:
+      - 01km
+      - 06km
+    shtfl:
+      - sfc
+    snod:
+      - sfc
+    soilm:
+      - sfc
+    soilt: &soilt_levs
+      - 0cm
+      - 1cm
+      - 4cm
+      - 10cm
+      - 30cm
+      - 60cm
+      - 1m
+      - 1.6m
+      - 3m
+    soilw: *soilt_levs
+    solar:
+      - sfc
+    ssrun:
+      - sfc
+    temp:
+      - 2ds
+      - 2m
+      - 500mb
+      - 700mb
+      - 850mb
+      - 925mb
+      - sfc
+    totp:
+      - sfc
+    trc1:
+      - sfc
+      - int
+    ulwrf:
+      - sfc
+      - top
+    uswrf:
+      - sfc
+      - top
+    vbdsf:
+      - sfc
+    vddsf:
+      - sfc
+    vig:
+      - sfc
+    vil:
+      - sfc
+    vis:
+      - sfc
+    vort:
+      - 500mb
+    vvel:
+      - 700mb
+      - mean
+    vvort:
+      - mx01
+      - mx02
+    weasd:
+      - sfc
+    wspeed:
+      - 10m
+      - 80m
+      - 250mb
+      - 850mb
+      - mdn
+      - mup


### PR DESCRIPTION
This update adds "regional_mpas" as a model configuration.  Currently (i.e., prior to this PR), GSL's regional MPAS configurations invoke pygraf using "hrrr" as the model configuration.  By creating this "regional_mpas" functionality, pygraf can now be freely adapted to support emerging MPAS plotting compatibility, but without risking longstanding HRRR compatibility. 

This "regional_mpas" configuration has an associated YAML file, and has several unique ncl_name handles (i.e., pointers to GRIB2 fields).  When/if the regional MPAS configurations are given a formal name for operational implementation (e.g., RRFSv2 or HRRRv5), the code instances of "regional_mpas" can be renamed, as needed.

Testing has been successful on Jet using recent GRIB2 files from the "MPAS_physics_dev1" system. 