### PR TITLE
Revising plots of vertical shear; enabling plots of cloud base and max updraft for regional MPAS

### DIFF
--- a/adb_graphics/default_specs.yml
+++ b/adb_graphics/default_specs.yml
@@ -417,6 +417,10 @@ ceilexp2: # Ceiling - experimental no.2
   ua:
     <<: *ceil
     ncl_name: 
+      # Note that the "HGT_P0_L2_{grid}" ncl_names in RAPv5/HRRRv4 (below)
+      # seemingly correspond to cloud-base height.  This is intentional; i.e.,
+      # the exp2 ceiling field was indeed implemented into operations by being 
+      # labeled as the cloud-base height.
       hrrr: HGT_P0_L2_{grid}
       hrrrhi: HGT_P0_L2_{grid}
       hrrrcar: HGT_P0_L2_{grid}
@@ -424,6 +428,13 @@ ceilexp2: # Ceiling - experimental no.2
       rrfs: CEIL_P0_L2_{grid}
       regional_mpas: CEIL_P0_L2_{grid}
     title: Ceiling (exp-2)
+cloudbase: # Cloud-base height
+  ua:
+    <<: *ceil
+    ncl_name:
+      rrfs: HGT_P0_L2_{grid}
+      regional_mpas: HGT_P0_L2_{grid}
+    title: Cloud-Base Height
 cfrzr: # Categorical Freezing Rain
   sfc:
     ncl_name: CFRZR_P0_L1_{grid}
@@ -454,12 +465,6 @@ cin: # Surface Convective Inhibition
   sfclt:
     <<: *sfc_cin
     title: Surface CIN < -50
-cloudbase: # Cloud-base height
-  ua:
-    <<: *ceil
-    ncl_name:
-      rrfs: HGT_P0_L2_{grid}
-    title: Cloud-Base Height
 cloudcover:
   bndylay: &cld_cover # PBL ... 1 km Cloud Cover
     clevs: [2, 5, 10, 20, 30, 40, 50, 60, 70, 80, 90, 95]
@@ -2163,7 +2168,9 @@ wspeed: # Wind Speed
     clevs: [0.5, 1, 1.5, 2, 2.5, 5, 7.5, 10, 12.5, 15, 17.5, 20, 22.5, 25, 30, 35, 40]
     cmap: jet
     colors: mup_colors
-    ncl_name: MAXUVV_P8_2L108_{grid}_max1h
+    ncl_name: 
+      - MAXUVV_P8_2L108_{grid}_max1h
+      - MAXUVV_P8_2L100_{grid}_max1h
     ticks: 0
     title: Max Updraft Velocity (over prev hour)
     unit: m/s

--- a/adb_graphics/default_specs.yml
+++ b/adb_graphics/default_specs.yml
@@ -1497,30 +1497,33 @@ seasalt: # Fine dust, global chem
     unit: $\mu g/m^3$
 shear:
   01km: &shear # 0-1 km
-    clevs: !!python/object/apply:numpy.arange [5, 91, 5]
-    cmap: jet
-    colors: shear_colors
+    clevs: [5, 10, 20, 30, 40, 50, 60]
+    cmap: gist_ncar
+    colors: wind_colors_high
     ncl_name: VUCSH_P0_2L103_{grid}
     split: True
     transform:
-      funcs: vector_magnitude
+      funcs: [vector_magnitude, conversions.ms_to_kt]
       kwargs:
         field2: VVCSH_P0_2L103_{grid}
         one_lev: True
         split: True
         level: 01km
     ticks: 0
-    unit: s$^{-1}$
+    title: 0–1 km Bulk Shear
+    unit: kt
   06km: # 0-6 km
     <<: *shear
+    clevs: [20, 30, 40, 50, 60, 70, 80, 90, 100]
     split: True
     transform:
-      funcs: vector_magnitude
+      funcs: [vector_magnitude, conversions.ms_to_kt]
       kwargs:
         field2: VVCSH_P0_2L103_{grid}
         one_lev: True
         split: True
         level: 06km
+    title: 0–6 km Bulk Shear
 shtfl: # Sensible Heat Net Flux
   sfc: &shtflsfc
     cmap: magma_r

--- a/image_lists/regional_mpas_subset.yml
+++ b/image_lists/regional_mpas_subset.yml
@@ -26,6 +26,8 @@ hourly:
       - ua
     ceilexp2:
       - ua
+    cloudbase:
+      - ua
     cloudcover:
       - bndylay
       - high


### PR DESCRIPTION
This PR accomplishes the following changes:

1) Plots of 0-1 and 0–6-km shear are revised for all model configurations (e.g., HRRR, RRFS, MPAS).  The proposed updates include clarified title bars / descriptions, re-expressed units (kts), and modified color bars.  The intent is to improve the usability of these shear plots, especially for characterizing convective environments.  Examples of the existing plots (left) and revised plots (right) are shown below:

<img width="1417" alt="0-6" src="https://github.com/user-attachments/assets/29c5bca7-69d5-4711-a048-583ed3f6900f" />
<img width="1415" alt="0-1" src="https://github.com/user-attachments/assets/4de2487f-20f7-4d04-8f61-b7e31a920983" />


Regarding these shear plots, I attempted to overlay the shear vectors (represented as barbs), but I could not get pygraf to produce the overlay (the attempted code crashed).  For now, we continue to plot only the shear _magnitude_.  Advice is welcome!

2) For regional MPAS applications, plots of cloud-base height and hourly-maximum updraft velocity are enabled.

Testing has been successful on Jet using recent GRIB2 output from **MPAS_physics_dev1**.  Copying @daviddowellNOAA for awareness.
