### PR TITLE
GFS_flux_products

### DIFF
--- a/adb_graphics/default_specs.yml
+++ b/adb_graphics/default_specs.yml
@@ -653,6 +653,16 @@ dlwrf: # Downward Longwave Radiation Flux
     ticks: 20
     title: Incoming Longwave Radiation Flux, TOA
     unit: W/m$^{2}$
+dlwrfavg: # Average Downward Longwave Radiation Flux
+  sfc:
+    <<: *radiation_flux
+    clevs: !!python/object/apply:numpy.arange [200, 501, 12]
+    cmap: gist_ncar
+    colors: radiation_colors
+    ncl_name: DLWRF_P0_L1_{grid}_avg6h
+    ticks: -2
+    title: Downward Longwave Radiation Flux 6h Avg, Surface
+    unit: W/m$^{2}$
 dswrf: # Downward Shortwave Radiation Flux
   sfc:
     <<: *radiation_flux
@@ -669,6 +679,14 @@ dswrf: # Downward Shortwave Radiation Flux
     ncl_name: DSWRF_P0_L8_{grid}
     ticks: 40
     title: Incoming Shortwave Radiation Flux, TOA
+dswrfavg: # Downward Shortwave Radiation Flux Average
+  sfc:
+    <<: *radiation_flux
+    clevs: [0, 50, 100, 150, 200, 250, 300, 400, 500, 600, 700, 800, 900, 1000]
+    colors: rainbow12_colors
+    ncl_name: DSWRF_P8_L1_{grid}_avg6h
+    ticks: 0
+    title: Downward Shortwave Radiation Flux 6h Avg, Surface
 fd: # Fine dust, global chem
   sfc:
     clevs: [1, 2, 4, 6, 8, 12, 16, 20, 25, 30, 40, 60, 100, 200]
@@ -1126,7 +1144,7 @@ lhtflavg:
   sfc:
     <<: *lhtflsfc
     ncl_name: LHTFL_P8_L1_{grid}_avg6h
-    title: Avg Latent Heat Net Flux
+    title: Latent Heat Net Flux 6h Avg
 li: # Lifted Index
   best: &lifted_index
     clevs: !!python/object/apply:numpy.arange [-15, 16]
@@ -1540,7 +1558,7 @@ shtflavg:
   sfc:
     <<: *shtflsfc
     ncl_name: SHTFL_P8_L1_{grid}_avg6h
-    title: Avg Sensible Heat Net Flux
+    title: Sensible Heat Net Flux 6h Avg
 sipd: # Supercooled Large Droplet Icing
   # levels chosen are arbitrary based on initial plot samples
   # additional levels may be requested in the future.
@@ -1933,6 +1951,24 @@ ulwrf: # Upward Longwave Radiation Flux
     ticks: 20
     title: Outgoing Longwave Radiation Flux, TOA
     unit: W/m$^{2}$
+ulwrfavg: # Upward Longwave Radiation Flux
+  sfc:
+    <<: *radiation_flux
+    clevs: !!python/object/apply:numpy.arange [350, 601, 10]
+    cmap: gist_ncar
+    colors: radiation_colors
+    ncl_name: ULWRF_P0_L1_{grid}_avg6h
+    ticks: -2
+    title: Upward Longwave Radiation Flux, Surface
+    unit: W/m$^{2}$
+  top: # Nominal top of atmosphere
+    clevs: !!python/object/apply:numpy.arange [80, 341, 2]
+    cmap: ir_rgbv_r
+    colors: radiation_mix_colors
+    ncl_name: ULWRF_P0_L8_{grid}_avg6h
+    ticks: 20
+    title: Outgoing Longwave Radiation Flux, TOA
+    unit: W/m$^{2}$
 uswrf: # Upward Shortwave Radiation Flux
   sfc:
     <<: *radiation_flux
@@ -1949,6 +1985,22 @@ uswrf: # Upward Shortwave Radiation Flux
     ncl_name: USWRF_P0_L8_{grid}
     ticks: 40
     title: Outgoing Shortwave Radiation Flux, TOA
+uswrfavg: # Upward Shortwave Radiation Flux Average
+  sfc:
+    <<: *radiation_flux
+    clevs: [0, 50, 100, 150, 200, 250, 300, 400, 500, 600, 700, 800, 900, 1000]
+    colors: rainbow12_colors
+    ncl_name: USWRF_P8_L1_{grid}_avg6h
+    ticks: 0
+    title: Upward Shortwave Radiation Flux 6h Avg, Surface
+  top: # Nominal top of atmosphere
+    <<: *radiation_flux
+    clevs: !!python/object/apply:numpy.arange [50, 851, 10]
+    cmap: Greys_r
+    colors: radiation_bw_colors
+    ncl_name: USWRF_P8_L8_{grid}_avg6h
+    ticks: 40
+    title: Outgoing Shortwave Radiation Flux 6h Avg, TOA
 v:
   10m: &agl_wind
     ncl_name: VGRD_P0_L103_{grid}

--- a/adb_graphics/figures/maps.py
+++ b/adb_graphics/figures/maps.py
@@ -627,7 +627,7 @@ class DataMap():
         else:
             level = level if not isinstance(level, list) else level[0]
             title = f'{level} {lev_unit} {f.field.long_name} {units}'
-        plt.title(f"{title}", position=(0.5, 1.08), fontsize=18)
+        plt.title(f"{title}", position=(0.5, 1.10), fontsize=18)
 
         # Two lines for hatched data (top), and contoured data (bottom) on the right
         contoured = self._set_overlay_string()

--- a/image_lists/global.yml
+++ b/image_lists/global.yml
@@ -27,7 +27,11 @@ hourly:
       - 2m
     dlwrf:
       - sfc
+    dlwrfavg:
+      - sfc
     dswrf:
+      - sfc
+    dswrfavg:
       - sfc
     gh:
       - 500mb
@@ -72,8 +76,14 @@ hourly:
       - sfc
     ulwrf:
       - sfc
+    ulwrfavg:
+      - sfc
+      - top
     uswrf:
       - sfc
+    uswrfavg:
+      - sfc
+      - top
     vis:
       - sfc
     vort:


### PR DESCRIPTION
Changes to plot 6h average flux products for GFS.  They use the same color table and contour intervals as the instantaneous plots, but are named differently and have titles that indicate that they are 6h averages.  Also a small adjustment to the title vertical position to avoid overrunning with other header lines.

![image](https://github.com/user-attachments/assets/c58bc5ad-7a73-4019-9f97-53aa2666ca2b)
![image](https://github.com/user-attachments/assets/c35bd856-c73f-4771-bd28-71a17ff9cd51)

These example images have different sizes, and the length of the title may somehow affect the overall image size.  I'll run some tests to see if this is the case.

